### PR TITLE
fix base64 encoding bug

### DIFF
--- a/Sources/VaporJWT/Encodings/Base64Encoding.swift
+++ b/Sources/VaporJWT/Encodings/Base64Encoding.swift
@@ -1,18 +1,14 @@
 import Core
-import Foundation
 
 public struct Base64Encoding: Encoding {
 
     public init() {}
 
     public func encode(_ bytes: Bytes) throws -> String {
-        return bytes.base64String
+        return bytes.base64Encoded.string
     }
 
     public func decode(_ base64Encoded: String) throws -> Bytes {
-        guard let data = Data(base64Encoded: base64Encoded) else {
-            throw JWTError.decoding
-        }
-        return try data.makeBytes()
+        return base64Encoded.bytes.base64Decoded
     }
 }

--- a/Sources/VaporJWT/Encodings/Base64URLEncoding.swift
+++ b/Sources/VaporJWT/Encodings/Base64URLEncoding.swift
@@ -13,7 +13,7 @@ public struct Base64URLEncoding: Encoding {
     }
 
     public func encode(_ bytes: Bytes) throws -> String {
-        guard let base64URL = base64URLTranscoder.base64URLEncode( bytes.base64String) else {
+        guard let base64URL = base64URLTranscoder.base64URLEncode(bytes.base64Encoded.string) else {
             throw JWTError.encoding
         }
         return base64URL

--- a/Tests/VaporJWTTests/EncodingTests.swift
+++ b/Tests/VaporJWTTests/EncodingTests.swift
@@ -35,8 +35,8 @@ final class EncodingTests: XCTestCase {
         }
     }
 
-    func testBase64DecodeThrowsErrorForInvalidString() {
-        assert(try Base64Encoding().decode("\0"), throws: JWTError.decoding)
+    func testBase64DecodeIgnoresErrorForInvalidString() throws {
+        _ = try Base64Encoding().decode("\0")
     }
 
     func testBase64URLEncodeThrowsErrorForInvalidString() {
@@ -52,7 +52,7 @@ final class EncodingTests: XCTestCase {
     static let all = [
         ("testBase64ToBase64URL", testBase64ToBase64URL),
         ("testBase64URLToBase64", testBase64URLToBase64),
-        ("testBase64DecodeThrowsErrorForInvalidString", testBase64DecodeThrowsErrorForInvalidString),
+        ("testBase64DecodeIgnoresErrorForInvalidString", testBase64DecodeIgnoresErrorForInvalidString),
         ("testBase64URLEncodeThrowsErrorForInvalidString",
         testBase64URLEncodeThrowsErrorForInvalidString),
         ("testBase64URLDecodeThrowsErrorForInvalidString",


### PR DESCRIPTION
I was having an issue where the following JWT token was resulting in a `JWTError.decoding`

```
eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyIjp7ImlkIjoiNzk0RkRFQ0EtNUNGNi00NzI3LThFOEMtQTY4MEM0NTE1OTlEIiwibmFtZSI6IlZhcG9yIFRlc3QifX0=.LjE98FgjMOfoWYoQp+kKTsOMhHO3mhgmSJ+E9uF1lxF6Iboe58s\/Ojt20bXNIFj7+y6krBwp+l0txGoIViJrTw==
```

I think somewhere in here lies a `\0` or some other unknown base64 character. Not quite sure what's causing these to get encoded into the base64--maybe that's an issue with how we're encoding base64 and this should be fixed there.

Either way, Core ignores invalid base64 characters when parsing. With that added, this token is working perfectly now.