### PR TITLE
rsa public/private key

### DIFF
--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -23,17 +23,19 @@ public struct JWT {
     /// - throws: Any error thrown while encoding or signing
     ///
     /// - returns: A JWT value
-    public init(headers: Node,
-                payload: Node,
-                encoding: Encoding = Base64Encoding(),
-                signer: Signer) throws {
+    public init(
+        headers: Node,
+        payload: Node,
+        encoding: Encoding = Base64Encoding(),
+        signer: Signer
+    ) throws {
         self.headers = headers
         self.payload = payload
         self.encoding = encoding
 
         let encoded = try [headers, payload].map(encoding.encode)
         let message = encoded.joined(separator: JWT.separator)
-        let bytes = try signer.sign(message.bytes)
+        let bytes = try signer.sign(message: message.bytes)
         signature = try encoding.encode(bytes)
     }
 
@@ -48,10 +50,12 @@ public struct JWT {
     /// - throws: Any error thrown while encoding or signing
     ///
     /// - returns: A JWT value
-    public init(additionalHeaders: [Header] = [],
-                payload: Node,
-                encoding: Encoding = Base64Encoding(),
-                signer: Signer) throws {
+    public init(
+        additionalHeaders: [Header] = [],
+        payload: Node,
+        encoding: Encoding = Base64Encoding(),
+        signer: Signer
+    ) throws {
         let headers: [Header] = [TypeHeader(), AlgorithmHeader(signer: signer)] + additionalHeaders
         try self.init(
             headers: Node(headers),
@@ -69,8 +73,10 @@ public struct JWT {
     ///           separated segments or any error thrown while decoding
     ///
     /// - returns: A JWT value
-    public init(token: String,
-                encoding: Encoding = Base64Encoding()) throws {
+    public init(
+        token: String,
+        encoding: Encoding = Base64Encoding()
+    ) throws {
         let segments = token.components(separatedBy: JWT.separator)
 
         guard segments.count == 3 else {

--- a/Sources/JWT/JWTError.swift
+++ b/Sources/JWT/JWTError.swift
@@ -7,4 +7,7 @@ public enum JWTError: Error {
     case missingAlgorithm
     case signing
     case wrongAlgorithm
+    case verificationFailed
+    case privateKeyRequired
+    case unknown(Error)
 }

--- a/Sources/JWT/JWTError.swift
+++ b/Sources/JWT/JWTError.swift
@@ -12,3 +12,36 @@ public enum JWTError: Error {
     // allow for future additions
     case unknown(Error)
 }
+
+extension JWTError: CustomStringConvertible {
+    public var description: String {
+        let reason: String
+
+        switch self {
+        case .createKey:
+            reason = "Could not create key"
+        case .createPublicKey:
+            reason = "Could not create public key"
+        case .decoding:
+            reason = "Could not decode"
+        case .encoding:
+            reason = "Could not encode"
+        case .incorrectNumberOfSegments:
+            reason = "Incorrect number of segments"
+        case .missingAlgorithm:
+            reason = "Missing algorithm"
+        case .privateKeyRequired:
+            reason = "Private key required"
+        case .signing:
+            reason = "Could not sign"
+        case .wrongAlgorithm:
+            reason = "Wrong algorithm"
+        case .verificationFailed:
+            reason = "Verification failed"
+        case .unknown(let error):
+            reason = "\(error)"
+        }
+
+        return "JWT error: \(reason)"
+    }
+}

--- a/Sources/JWT/JWTError.swift
+++ b/Sources/JWT/JWTError.swift
@@ -5,9 +5,10 @@ public enum JWTError: Error {
     case encoding
     case incorrectNumberOfSegments
     case missingAlgorithm
+    case privateKeyRequired
     case signing
     case wrongAlgorithm
     case verificationFailed
-    case privateKeyRequired
+    // allow for future additions
     case unknown(Error)
 }

--- a/Sources/JWT/SignatureVerifiable.swift
+++ b/Sources/JWT/SignatureVerifiable.swift
@@ -11,9 +11,10 @@ extension SignatureVerifiable {
     ///
     /// - parameter signer: used to verify the signature
     ///
-    /// - throws: JWTError.wrongAlgorithm if the algorithm does not match. Throws any error thrown while signing or encoding.
-    ///
-    /// - returns: True is the signature was verified, false otherwise.
+    /// - throws: 
+    ///     - `JWTError.wrongAlgorithm` if the algorithm does not match.
+    ///     - `JWTError.verificationFailed` if the signer cannot verify the JWT.
+    ///     - Any error thrown while signing or encoding.
     public func verifySignature(using signer: Signer) throws {
         guard signer.name == algorithmName else {
             throw JWTError.wrongAlgorithm

--- a/Sources/JWT/SignatureVerifiable.swift
+++ b/Sources/JWT/SignatureVerifiable.swift
@@ -7,12 +7,6 @@ public protocol SignatureVerifiable {
 }
 
 extension SignatureVerifiable {
-
-    @available(*, deprecated, message: "Use `verifySignature(using:)` instead")
-    public func verifySignatureWith(_ signer: Signer) throws -> Bool {
-        return try verifySignature(using: signer)
-    }
-
     /// Verifies signature
     ///
     /// - parameter signer: used to verify the signature
@@ -20,11 +14,14 @@ extension SignatureVerifiable {
     /// - throws: JWTError.wrongAlgorithm if the algorithm does not match. Throws any error thrown while signing or encoding.
     ///
     /// - returns: True is the signature was verified, false otherwise.
-    public func verifySignature(using signer: Signer) throws -> Bool {
+    public func verifySignature(using signer: Signer) throws {
         guard signer.name == algorithmName else {
             throw JWTError.wrongAlgorithm
         }
-        return try signer.verifySignature(
-            try createSignature(), message: try createMessage())
+
+        try signer.verify(
+            signature: try createSignature(),
+            message: try createMessage()
+        )
     }
 }

--- a/Sources/JWT/Signers/ECDSASigner.swift
+++ b/Sources/JWT/Signers/ECDSASigner.swift
@@ -4,9 +4,9 @@ import Foundation
 import Hash
 
 public final class ES256: ECDSASigner {
-    public let curve = NID_X9_62_prime256v1
-    public let key: Bytes
-    public let method = Hash.Method.sha256
+    let curve = NID_X9_62_prime256v1
+    let key: Bytes
+    let method = Hash.Method.sha256
 
     public init(key: Bytes) {
         self.key = key
@@ -14,9 +14,9 @@ public final class ES256: ECDSASigner {
 }
 
 public final class ES384: ECDSASigner {
-    public let curve = NID_secp384r1
-    public let key: Bytes
-    public let method = Hash.Method.sha384
+    let curve = NID_secp384r1
+    let key: Bytes
+    let method = Hash.Method.sha384
 
     public init(key: Bytes) {
         self.key = key
@@ -24,16 +24,16 @@ public final class ES384: ECDSASigner {
 }
 
 public final class ES512: ECDSASigner {
-    public let curve = NID_secp521r1
-    public let key: Bytes
-    public let method = Hash.Method.sha512
+    let curve = NID_secp521r1
+    let key: Bytes
+    let method = Hash.Method.sha512
 
     public init(key: Bytes) {
         self.key = key
     }
 }
 
-public protocol ECDSASigner: Signer, BytesConvertible {
+protocol ECDSASigner: Signer, BytesConvertible {
     init(key: Bytes)
     var key: Bytes { get }
     var curve: Int32 { get }

--- a/Sources/JWT/Signers/ECDSASigner.swift
+++ b/Sources/JWT/Signers/ECDSASigner.swift
@@ -3,43 +3,55 @@ import Core
 import Foundation
 import Hash
 
-public struct ES256: ECDSASigner {
+public class ES256: ECDSASigner {
     public let curve = NID_X9_62_prime256v1
     public let key: Bytes
     public let method = Hash.Method.sha256
 
-    public init(key: Bytes) {
+    public required init(key: Bytes) {
         self.key = key
     }
 }
 
-public struct ES384: ECDSASigner {
+public class ES384: ECDSASigner {
     public let curve = NID_secp384r1
     public let key: Bytes
     public let method = Hash.Method.sha384
 
-    public init(key: Bytes) {
+    public required init(key: Bytes) {
         self.key = key
     }
 }
 
-public struct ES512: ECDSASigner {
+public class ES512: ECDSASigner {
     public let curve = NID_secp521r1
     public let key: Bytes
     public let method = Hash.Method.sha512
 
-    public init(key: Bytes) {
+    public required init(key: Bytes) {
         self.key = key
     }
 }
 
-public protocol ECDSASigner: Key, Signer {
+public protocol ECDSASigner: Signer, BytesConvertible {
+    init(key: Bytes)
+    var key: Bytes { get }
     var curve: Int32 { get }
     var method: Hash.Method { get }
 }
 
 extension ECDSASigner {
-    public func sign(_ message: Bytes) throws -> Bytes {
+    public init(bytes: Bytes) {
+        self.init(key: bytes)
+    }
+
+    public func makeBytes() -> Bytes {
+        return key
+    }
+}
+
+extension ECDSASigner {
+    public func sign(message: Bytes) throws -> Bytes {
         var digest = try Hash(method, message).hash()
         let ecKey = try newECKeyPair()
 
@@ -63,13 +75,15 @@ extension ECDSASigner {
         return derBytes
     }
 
-    public func verifySignature(_ der: Bytes, message: Bytes) throws -> Bool {
+    public func verify(signature der: Bytes, message: Bytes) throws {
         var signaturePointer: UnsafePointer? = UnsafePointer(der)
         let signature = d2i_ECDSA_SIG(nil, &signaturePointer, der.count)
         let digest = try Hash(method, message).hash()
         let ecKey = try newECPublicKey()
         let verified = ECDSA_do_verify(digest, Int32(digest.count), signature, ecKey)
-        return verified == 1
+        guard verified == 1 else {
+            throw JWTError.verificationFailed
+        }
     }
 }
 

--- a/Sources/JWT/Signers/ECDSASigner.swift
+++ b/Sources/JWT/Signers/ECDSASigner.swift
@@ -3,32 +3,32 @@ import Core
 import Foundation
 import Hash
 
-public class ES256: ECDSASigner {
+public final class ES256: ECDSASigner {
     public let curve = NID_X9_62_prime256v1
     public let key: Bytes
     public let method = Hash.Method.sha256
 
-    public required init(key: Bytes) {
+    public init(key: Bytes) {
         self.key = key
     }
 }
 
-public class ES384: ECDSASigner {
+public final class ES384: ECDSASigner {
     public let curve = NID_secp384r1
     public let key: Bytes
     public let method = Hash.Method.sha384
 
-    public required init(key: Bytes) {
+    public init(key: Bytes) {
         self.key = key
     }
 }
 
-public class ES512: ECDSASigner {
+public final class ES512: ECDSASigner {
     public let curve = NID_secp521r1
     public let key: Bytes
     public let method = Hash.Method.sha512
 
-    public required init(key: Bytes) {
+    public init(key: Bytes) {
         self.key = key
     }
 }

--- a/Sources/JWT/Signers/HMACSigner.swift
+++ b/Sources/JWT/Signers/HMACSigner.swift
@@ -2,8 +2,8 @@ import Core
 import HMAC
 
 public final class HS256: HMACSigner {
-    public let key: Bytes
-    public let method = HMAC.Method.sha256
+    let key: Bytes
+    let method = HMAC.Method.sha256
 
     public init(key: Bytes) {
         self.key = key
@@ -11,8 +11,8 @@ public final class HS256: HMACSigner {
 }
 
 public final class HS384: HMACSigner {
-    public let key: Bytes
-    public let method = HMAC.Method.sha384
+    let key: Bytes
+    let method = HMAC.Method.sha384
 
     public init(key: Bytes) {
         self.key = key
@@ -20,15 +20,15 @@ public final class HS384: HMACSigner {
 }
 
 public final class HS512: HMACSigner {
-    public let key: Bytes
-    public let method = HMAC.Method.sha256
+    let key: Bytes
+    let method = HMAC.Method.sha256
 
     public init(key: Bytes) {
         self.key = key
     }
 }
 
-public protocol HMACSigner: Signer, BytesConvertible {
+protocol HMACSigner: Signer, BytesConvertible {
     init(key: Bytes)
     var key: Bytes { get }
     var method: HMAC.Method { get }

--- a/Sources/JWT/Signers/HMACSigner.swift
+++ b/Sources/JWT/Signers/HMACSigner.swift
@@ -1,29 +1,29 @@
 import Core
 import HMAC
 
-public class HS256: HMACSigner {
+public final class HS256: HMACSigner {
     public let key: Bytes
     public let method = HMAC.Method.sha256
 
-    public required init(key: Bytes) {
+    public init(key: Bytes) {
         self.key = key
     }
 }
 
-public class HS384: HMACSigner {
+public final class HS384: HMACSigner {
     public let key: Bytes
     public let method = HMAC.Method.sha384
 
-    public required init(key: Bytes) {
+    public init(key: Bytes) {
         self.key = key
     }
 }
 
-public class HS512: HMACSigner {
+public final class HS512: HMACSigner {
     public let key: Bytes
     public let method = HMAC.Method.sha256
 
-    public required init(key: Bytes) {
+    public init(key: Bytes) {
         self.key = key
     }
 }

--- a/Sources/JWT/Signers/HMACSigner.swift
+++ b/Sources/JWT/Signers/HMACSigner.swift
@@ -1,43 +1,57 @@
 import Core
 import HMAC
 
-public struct HS256: HMACSigner {
+public class HS256: HMACSigner {
     public let key: Bytes
     public let method = HMAC.Method.sha256
 
-    public init(key: Bytes) {
+    public required init(key: Bytes) {
         self.key = key
     }
 }
 
-public struct HS384: HMACSigner {
+public class HS384: HMACSigner {
     public let key: Bytes
     public let method = HMAC.Method.sha384
 
-    public init(key: Bytes) {
+    public required init(key: Bytes) {
         self.key = key
     }
 }
 
-public struct HS512: HMACSigner {
+public class HS512: HMACSigner {
     public let key: Bytes
     public let method = HMAC.Method.sha256
 
-    public init(key: Bytes) {
+    public required init(key: Bytes) {
         self.key = key
     }
 }
 
-public protocol HMACSigner: Signer, Key {
+public protocol HMACSigner: Signer, BytesConvertible {
+    init(key: Bytes)
+    var key: Bytes { get }
     var method: HMAC.Method { get }
 }
 
 extension HMACSigner {
-    public func sign(_ message: Bytes) throws -> Bytes {
+    public init(bytes: Bytes) {
+        self.init(key: bytes)
+    }
+
+    public func makeBytes() -> Bytes {
+        return key
+    }
+}
+
+extension HMACSigner {
+    public func sign(message: Bytes) throws -> Bytes {
         return try HMAC.make(method, message, key: key)
     }
 
-    public func verifySignature(_ signature: Bytes, message: Bytes) throws -> Bool {
-        return try sign(message) == signature
+    public func verify(signature: Bytes, message: Bytes) throws {
+        guard try sign(message: message) == signature else {
+            throw JWTError.verificationFailed
+        }
     }
 }

--- a/Sources/JWT/Signers/RSASigner.swift
+++ b/Sources/JWT/Signers/RSASigner.swift
@@ -26,67 +26,117 @@ extension HashMethod {
     }
 }
 
-public struct RS256: RSASigner {
-    public let key: Bytes
+public typealias CRSAKey = UnsafeMutablePointer<RSA>
+
+public enum RSAKey {
+    case `public`(CRSAKey)
+    case `private`(CRSAKey)
+
+    public init(_ rawKey: Bytes) throws {
+        if let rsa = rawKey.withUnsafeBufferPointer({ p -> CRSAKey! in
+            var baseAddress = p.baseAddress
+            return d2i_RSAPrivateKey(nil, &baseAddress, rawKey.count)
+        }) {
+            self = .private(rsa)
+        } else if let rsa = rawKey.withUnsafeBufferPointer({ p -> CRSAKey! in
+            var baseAddress = p.baseAddress
+            return d2i_RSA_PUBKEY(nil, &baseAddress, rawKey.count)
+        }) {
+            self = .public(rsa)
+        } else {
+            throw JWTError.createKey
+        }
+    }
+
+    var cKey: CRSAKey {
+        switch self {
+        case .public(let cKey):
+            return cKey
+        case .private(let cKey):
+            return cKey
+        }
+    }
+}
+
+public class RS256: RSASigner {
+    public let key: RSAKey
     public let hashMethod = HashMethod.sha256
 
-    public init(key: Bytes) {
-        self.key = key
+    public required init(key: Bytes) throws {
+        self.key = try RSAKey(key)
     }
 }
 
-public struct RS384: RSASigner {
-    public let key: Bytes
+public class RS384: RSASigner {
+    public let key: RSAKey
     public let hashMethod = HashMethod.sha384
 
-    public init(key: Bytes) {
-        self.key = key
+    public required init(key: Bytes) throws {
+        self.key = try RSAKey(key)
     }
 }
 
-public struct RS512: RSASigner {
-    public let key: Bytes
+public class RS512: RSASigner {
+    public let key: RSAKey
     public let hashMethod = HashMethod.sha512
 
-    public init(key: Bytes) {
-        self.key = key
+    public required init(key: Bytes) throws {
+        self.key = try RSAKey(key)
     }
 }
 
-public protocol RSASigner: Key, Signer {
+public protocol RSASigner: Signer, BytesInitializable {
+    var key: RSAKey { get }
     var hashMethod: HashMethod { get }
+    init(key: Bytes) throws
 }
 
 extension RSASigner {
-    public func sign(_ message: Bytes) throws -> Bytes {
-        guard let rsa = key.withUnsafeBufferPointer({ p -> UnsafeMutablePointer<RSA>! in
-            var baseAddress = p.baseAddress
-            return d2i_RSAPrivateKey(nil, &baseAddress, key.count)
-        }) else {
-            throw JWTError.createKey
+    public init(bytes: Bytes) throws {
+        try self.init(key: bytes)
+    }
+}
+
+extension RSASigner {
+    public func sign(message: Bytes) throws -> Bytes {
+        guard case .private(let cKey) = key else {
+            throw JWTError.privateKeyRequired
         }
 
         var siglen: UInt32 = 0
-        var sig = Bytes(repeating: 0, count: Int(RSA_size(rsa)))
+        var sig = Bytes(
+            repeating: 0,
+            count: Int(RSA_size(cKey))
+        )
 
         let digest = try Hash(hashMethod.method, message).hash()
 
-        RSA_sign(hashMethod.type, digest, UInt32(digest.count), &sig, &siglen, rsa)
+        RSA_sign(
+            hashMethod.type,
+            digest,
+            UInt32(digest.count),
+            &sig,
+            &siglen,
+            cKey
+        )
 
         return sig
     }
 
-    public func verifySignature(_ signature: Bytes, message: Bytes) throws -> Bool {
-        guard let rsa = key.withUnsafeBufferPointer({ p -> UnsafeMutablePointer<RSA>! in
-            var baseAddress = p.baseAddress
-            return d2i_RSA_PUBKEY(nil, &baseAddress, key.count)
-        }) else {
-            throw JWTError.createPublicKey
-        }
-
+    public func verify(signature: Bytes, message: Bytes) throws {
         let digest = try Hash(hashMethod.method, message).hash()
 
-        return RSA_verify(hashMethod.type, digest, UInt32(digest.count), signature,
-                          UInt32(signature.count), rsa) == 1
+        let result = RSA_verify(
+            hashMethod.type,
+            digest,
+            UInt32(digest.count),
+            signature,
+            UInt32(signature.count),
+            key.cKey
+        )
+
+        guard result == 1 else {
+            throw JWTError.verificationFailed
+        }
     }
 }

--- a/Sources/JWT/Signers/RSASigner.swift
+++ b/Sources/JWT/Signers/RSASigner.swift
@@ -26,9 +26,9 @@ extension HashMethod {
     }
 }
 
-public typealias CRSAKey = UnsafeMutablePointer<RSA>
+typealias CRSAKey = UnsafeMutablePointer<RSA>
 
-public enum RSAKey {
+enum RSAKey {
     case `public`(CRSAKey)
     case `private`(CRSAKey)
 
@@ -62,8 +62,8 @@ public enum RSAKey {
 }
 
 public final class RS256: RSASigner {
-    public let key: RSAKey
-    public let hashMethod = HashMethod.sha256
+    let key: RSAKey
+    let hashMethod = HashMethod.sha256
 
     public init(key: Bytes) throws {
         self.key = try RSAKey(key)
@@ -71,8 +71,8 @@ public final class RS256: RSASigner {
 }
 
 public final class RS384: RSASigner {
-    public let key: RSAKey
-    public let hashMethod = HashMethod.sha384
+    let key: RSAKey
+    let hashMethod = HashMethod.sha384
 
     public init(key: Bytes) throws {
         self.key = try RSAKey(key)
@@ -80,15 +80,15 @@ public final class RS384: RSASigner {
 }
 
 public final class RS512: RSASigner {
-    public let key: RSAKey
-    public let hashMethod = HashMethod.sha512
+    let key: RSAKey
+    let hashMethod = HashMethod.sha512
 
     public init(key: Bytes) throws {
         self.key = try RSAKey(key)
     }
 }
 
-public protocol RSASigner: Signer, BytesInitializable {
+protocol RSASigner: Signer, BytesInitializable {
     var key: RSAKey { get }
     var hashMethod: HashMethod { get }
     init(key: Bytes) throws

--- a/Sources/JWT/Signers/Signer.swift
+++ b/Sources/JWT/Signers/Signer.swift
@@ -1,28 +1,30 @@
 import Core
 
+/// Some data structure capable of signing
+/// an array of bytes and later verifying
+/// a signature against a raw array of bytes
 public protocol Signer {
     var name: String { get }
-    func sign(_ message: Bytes) throws -> Bytes
-    func verifySignature(_ signature: Bytes, message: Bytes) throws -> Bool
+    func sign(message: Bytes) throws -> Bytes
+    func verify(signature: Bytes, message: Bytes) throws
 }
 
 extension Signer {
     public var name: String {
         return String(describing: Self.self)
     }
-}
 
-public protocol Key {
-    var key: Bytes { get }
-    init(key: Bytes)
-}
-
-extension Key {
-    public init(key: String) {
-        self.init(key: key.bytes)
+    func sign(message convertible: BytesConvertible) throws -> Bytes {
+        let bytes = try convertible.makeBytes()
+        return try sign(message: bytes)
     }
 
-    public init(encodedKey key: String, encoding: Encoding = Base64Encoding()) throws {
-        try self.init(key: encoding.decode(key))
+    func verify(signature: BytesConvertible, message: BytesConvertible) throws {
+        let signatureBytes = try signature.makeBytes()
+        let messageBytes = try message.makeBytes()
+        return try verify(
+            signature: signatureBytes,
+            message: messageBytes
+        )
     }
 }

--- a/Sources/JWT/Signers/Unsigned.swift
+++ b/Sources/JWT/Signers/Unsigned.swift
@@ -5,12 +5,11 @@ public struct Unsigned: Signer {
 
     public init() {}
 
-    public func sign(_ message: Bytes) throws -> Bytes {
+    public func sign(message: Bytes) throws -> Bytes {
         return []
     }
 
-    public func verifySignature(_ signature: Bytes,
-                                message: Bytes) throws -> Bool {
-        return true
+    public func verify(signature: Bytes, message: Bytes) throws {
+        // always pass
     }
 }

--- a/Tests/JWTTests/EncodingTests.swift
+++ b/Tests/JWTTests/EncodingTests.swift
@@ -40,22 +40,34 @@ final class EncodingTests: XCTestCase {
     }
 
     func testBase64URLEncodeThrowsErrorForInvalidString() {
-        assert(try Base64URLEncoding(base64URLTranscoder: TestBase64URLTranscoder()).encode(""),
-               throws: JWTError.encoding)
+        do {
+            _ = try Base64URLEncoding(
+                base64URLTranscoder: TestBase64URLTranscoder()
+            ).encode("")
+        } catch JWTError.encoding {
+            // pass
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
     }
 
     func testBase64URLDecodeThrowsErrorForInvalidString() {
-        assert(try Base64URLEncoding(base64URLTranscoder: TestBase64URLTranscoder()).decode(""),
-               throws: JWTError.decoding)
+        do {
+            _ = try Base64URLEncoding(
+                base64URLTranscoder: TestBase64URLTranscoder()
+            ).decode("")
+        } catch JWTError.decoding {
+            // pass
+        } catch {
+            XCTFail("Wrong error: \(error)")
+        }
     }
 
     static let all = [
         ("testBase64ToBase64URL", testBase64ToBase64URL),
         ("testBase64URLToBase64", testBase64URLToBase64),
         ("testBase64DecodeIgnoresErrorForInvalidString", testBase64DecodeIgnoresErrorForInvalidString),
-        ("testBase64URLEncodeThrowsErrorForInvalidString",
-        testBase64URLEncodeThrowsErrorForInvalidString),
-        ("testBase64URLDecodeThrowsErrorForInvalidString",
-        testBase64URLDecodeThrowsErrorForInvalidString),
+        ("testBase64URLEncodeThrowsErrorForInvalidString", testBase64URLEncodeThrowsErrorForInvalidString),
+        ("testBase64URLDecodeThrowsErrorForInvalidString", testBase64URLDecodeThrowsErrorForInvalidString),
     ]
 }

--- a/Tests/JWTTests/Helper/throwsError.swift
+++ b/Tests/JWTTests/Helper/throwsError.swift
@@ -1,10 +1,12 @@
 @testable import JWT
 import XCTest
 
-func assert<E: Error>(_ expression: @autoclosure () throws -> Any,
+func assert<E: Error>(
+    _ expression: @autoclosure () throws -> Any,
     throws expected: E,
     file: StaticString = #file,
-    line: UInt = #line)
+    line: UInt = #line
+)
     where E: Equatable {
         do {
             _ = try expression()

--- a/Tests/JWTTests/SignerTests.swift
+++ b/Tests/JWTTests/SignerTests.swift
@@ -5,84 +5,105 @@ import XCTest
 final class SignerTests: XCTestCase {
     let encoder = Base64Encoding()
 
-    func testUnsigned() {
+    func testUnsigned() throws {
         let signer = Unsigned()
         XCTAssertEqual(signer.name, "none")
-        XCTAssertEqual(try signer.sign("a".bytes), [])
-        XCTAssertTrue(try signer.verifySignature("a".bytes, message: "b".bytes))
+        XCTAssertEqual(try signer.sign(message: "a".bytes), [])
+        try signer.verify(signature: "a".bytes, message: "b".bytes)
     }
 
-    func checkHMACSigner(createSigner: (Bytes) -> HMACSigner,
-                         name: String,
-                         message: Bytes = "message".bytes,
-                         key: Bytes = "secret".bytes,
-                         signed: String,
-                         file: StaticString = #file,
-                         line: UInt = #line) {
+    func checkHMACSigner(
+        createSigner: (Bytes) -> HMACSigner,
+        name: String,
+        message: Bytes = "message".bytes,
+        key: Bytes = "secret".bytes,
+        signed: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
         let signer = createSigner(key)
         XCTAssertEqual(signer.name, name, file: file, line: line)
-        XCTAssertEqual(try encoder.encode(try signer.sign(message)), signed, file: file, line: line)
-        XCTAssertTrue(try signer.verifySignature(try encoder.decode(signed), message: message),
-                      file: file, line: line)
+        XCTAssertEqual(try encoder.encode(try signer.sign(message: message)), signed, file: file, line: line)
+        do {
+            try signer.verify(
+                signature: try encoder.decode(signed),
+                message: message
+            )
+        } catch {
+            XCTFail("Signature verification failed: \(error)", file: file, line: line)
+        }
     }
 
     func testHS256() {
-        checkHMACSigner(createSigner: HS256.init,
-                        name: "HS256",
-                        signed: "i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs=")
+        checkHMACSigner(
+            createSigner: HS256.init,
+            name: "HS256",
+            signed: "i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs="
+        )
     }
 
     func testHS384() {
-        checkHMACSigner(createSigner: HS384.init,
-                        name: "HS384",
-                        signed: "rQ706A2kJ7KjPURXyXK/dZ9Qdm+7ZlaQ1Qt8s43VIX21Wck+p8vuSOKuGltKr9NL")
+        checkHMACSigner(
+            createSigner: HS384.init,
+            name: "HS384",
+            signed: "rQ706A2kJ7KjPURXyXK/dZ9Qdm+7ZlaQ1Qt8s43VIX21Wck+p8vuSOKuGltKr9NL"
+        )
     }
 
     func testHS512() {
-        checkHMACSigner(createSigner: HS512.init,
-                        name: "HS512",
-                        signed: "i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs=")
+        checkHMACSigner(
+            createSigner: HS512.init,
+            name: "HS512",
+            signed: "i19IcCmVwVmMVz2x4hhmqbgl1KeU0WnXBgoDYFeWNgs="
+        )
     }
 
-    func checkSigner(createSigner: (Bytes) -> Signer,
-                     name: String,
-                     message: String = "message",
-                     privateKey: String,
-                     publicKey: String,
-                     file: StaticString = #file,
-                     line: UInt = #line) {
+    func checkSigner(
+        createSigner: (Bytes) throws -> Signer,
+        name: String,
+        message: String = "message",
+        privateKey: String,
+        publicKey: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
         do {
-            let signer = createSigner(try encoder.decode(privateKey))
-            let verifier = createSigner(try encoder.decode(publicKey))
+            let signer = try createSigner(try encoder.decode(privateKey))
+            let verifier = try createSigner(try encoder.decode(publicKey))
             XCTAssertEqual(signer.name, name, file: file, line: line)
 
-            let signature = try signer.sign(message.bytes)
-            XCTAssertTrue(try verifier.verifySignature(signature, message: message.bytes),
-                          file: file, line: line)
+            let signature = try signer.sign(message: message.bytes)
+            try verifier.verify(signature: signature, message: message.bytes)
         } catch {
             XCTFail("\(error)", file: file, line: line)
         }
     }
 
     func testES256() {
-        checkSigner(createSigner: ES256.init,
-                    name: "ES256",
-                    privateKey: "AL3BRa7llckPgUw3Si2KCy1kRUZJ/pxJ29nlr86xlm0=",
-                    publicKey: "BIMulrzGbr8b4Dzj/lR5/m69XXLXfFCU0hkXr9jvpsXzNovbyb0gJYkMxrrCyYqd9ofDcTSSIWxxEtL8h5KcNBY=")
+        checkSigner(
+            createSigner: ES256.init,
+            name: "ES256",
+            privateKey: "AL3BRa7llckPgUw3Si2KCy1kRUZJ/pxJ29nlr86xlm0=",
+            publicKey: "BIMulrzGbr8b4Dzj/lR5/m69XXLXfFCU0hkXr9jvpsXzNovbyb0gJYkMxrrCyYqd9ofDcTSSIWxxEtL8h5KcNBY="
+        )
     }
 
     func testES384() {
-        checkSigner(createSigner: ES384.init,
-                    name: "ES384",
-                    privateKey: "BVjgIwqB1PeIv0YP3ZeQ7CTqW+9+yJ7Y/jXPr1tfrb3ne5TQNMU2rOxYtf6M6IN9",
-                    publicKey: "BAV9NUl1v488eXcDhStPTK57Dg4Cm+XCjmFGD1IXjkF+LJNG963oUkYjV1xxNQgxJka7tsXjadei25PdZatX3GS6KivPiNu1YdeSpXxr5d73sdLU/rq/OgDLUUcic77g3A==")
+        checkSigner(
+            createSigner: ES384.init,
+            name: "ES384",
+            privateKey: "BVjgIwqB1PeIv0YP3ZeQ7CTqW+9+yJ7Y/jXPr1tfrb3ne5TQNMU2rOxYtf6M6IN9",
+            publicKey: "BAV9NUl1v488eXcDhStPTK57Dg4Cm+XCjmFGD1IXjkF+LJNG963oUkYjV1xxNQgxJka7tsXjadei25PdZatX3GS6KivPiNu1YdeSpXxr5d73sdLU/rq/OgDLUUcic77g3A=="
+        )
     }
 
     func testES512() {
-        checkSigner(createSigner: ES512.init,
-                    name: "ES512",
-                    privateKey: "AdcqLUGC+4OlxqGRJkz6++BD9tfDtNM1NvTQh7M0stzvMMvcaNio87YUD6Gaks0eS9Krvs1Bkqo/T7k9DW8Eyoec",
-                    publicKey: "BACJKkoouMqhbgZtTSyQJHECDf/V2ArN7VwuaIUIKsx/OFiF79ccrzCSZ1MrGOmQgPAez6pqjUIjhwoHr5tRH65BggEUhC7SNvRvfMeElOrZNac9uTVnfGJ1DywnL+JtD49ytuD9GjifUPHJi4RcN36RHLXyBpF0u1+RRFbKCNhnJ132Pw==")
+        checkSigner(
+            createSigner: ES512.init,
+            name: "ES512",
+            privateKey: "AdcqLUGC+4OlxqGRJkz6++BD9tfDtNM1NvTQh7M0stzvMMvcaNio87YUD6Gaks0eS9Krvs1Bkqo/T7k9DW8Eyoec",
+            publicKey: "BACJKkoouMqhbgZtTSyQJHECDf/V2ArN7VwuaIUIKsx/OFiF79ccrzCSZ1MrGOmQgPAez6pqjUIjhwoHr5tRH65BggEUhC7SNvRvfMeElOrZNac9uTVnfGJ1DywnL+JtD49ytuD9GjifUPHJi4RcN36RHLXyBpF0u1+RRFbKCNhnJ132Pw=="
+        )
     }
 
 
@@ -90,24 +111,41 @@ final class SignerTests: XCTestCase {
     let publicRSAKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAq9IyIvhllcz9dTubJair9stTDR/3OQtO87NeWwk/7/Pte13c5s4gQariuX+Q7KMAqjvR4s2Fn3Q7bNLroRkWEV0LpQA/ft056DVO4z3iqcplTGnGR1VHfKAKFquazV8QSgjq4+cD2A0rHCfk1PcAP0fB3Xc52f6yoYzZyW7tJvfd3QamHOu3zAXbpAkpUk0N5fn4bumL4rF4j5jiKcZDspNfhSrhDZpXW7TyWiMmDQLYtSvCj9MK6JW79fTr8WyRrXVmRXBnGFktKrnmkbsQba1GKwVDUCx6E+nm5ZStE8vcwuOy0U1EtrcjiDprM1uGCCvjcOOb40voxXoRN9szdwIDAQAB"
 
     func testRS256() {
-        checkSigner(createSigner: RS256.init,
-                    name: "RS256",
-                    privateKey: privateRSAKey,
-                    publicKey: publicRSAKey)
+        checkSigner(
+            createSigner: RS256.init,
+            name: "RS256",
+            privateKey: privateRSAKey,
+            publicKey: publicRSAKey
+        )
     }
 
     func testRS384() {
-        checkSigner(createSigner: RS384.init,
-                    name: "RS384",
-                    privateKey: privateRSAKey,
-                    publicKey: publicRSAKey)
+        checkSigner(
+            createSigner: RS384.init,
+            name: "RS384",
+            privateKey: privateRSAKey,
+            publicKey: publicRSAKey
+        )
     }
 
     func testRS512() {
-        checkSigner(createSigner: RS512.init,
-                    name: "RS512",
-                    privateKey: privateRSAKey,
-                    publicKey: publicRSAKey)
+        checkSigner(
+            createSigner: RS512.init,
+            name: "RS512",
+            privateKey: privateRSAKey,
+            publicKey: publicRSAKey
+        )
+    }
+
+    func testRSAPublicKeySignFails() throws {
+        do {
+            let signer = try RS512(bytes: encoder.decode(publicRSAKey))
+            _ = try signer.sign(message: "foo")
+        } catch JWTError.privateKeyRequired {
+            // pass
+        } catch {
+            XCTFail("Wrong error thrown: \(error)")
+        }
     }
 
     static let all = [
@@ -121,5 +159,5 @@ final class SignerTests: XCTestCase {
         ("testRS256", testRS256),
         ("testRS384", testRS384),
         ("testRS512", testRS512),
-        ]
+    ]
 }


### PR DESCRIPTION
Fixes #19 as well as cleans up code styling to better match Vapor org guidelines.

The `Key` protocol has been removed to allow Signers to have more freedom about how they store their keys. This allows the `RSASigner` to hold its key in a proprietary `RSAKey` format. Holding the key in this parsed format will make signing and verifying faster.

The `RSAKey` enum is a combination of what was discussed in #19. While it is an enum with public/private cases, it can be initialized by either a public or private key in the `init(Bytes) throws` method. This moves the computation for determining what type of a key it is to init time making sign and verify steps simpler.