### PR TITLE
Backport signature validation fixes from 0.11 to 0.8

### DIFF
--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -34,7 +34,7 @@ public struct JWT {
     public init(
         headers: Node,
         payload: Node,
-        encoding: Encoding = Base64Encoding(),
+        encoding: Encoding = Base64URLEncoding(),
         signer: Signer
     ) throws {
         self.headers = headers
@@ -62,7 +62,7 @@ public struct JWT {
     public init(
         additionalHeaders: [Header] = [],
         payload: Node,
-        encoding: Encoding = Base64Encoding(),
+        encoding: Encoding = Base64URLEncoding(),
         signer: Signer
     ) throws {
         let headers: [Header] = [TypeHeader(), AlgorithmHeader(signer: signer)] + additionalHeaders
@@ -84,7 +84,7 @@ public struct JWT {
     /// - returns: A JWT value
     public init(
         token: String,
-        encoding: Encoding = Base64Encoding()
+        encoding: Encoding = Base64URLEncoding()
     ) throws {
         let segments = token.components(separatedBy: JWT.separator)
 

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -12,6 +12,14 @@ public struct JWT {
     public let payload: Node
     public let signature: String
 
+    /// Used to store the token that created this
+    /// JWT if it was parsed
+    public let rawToken: (
+        header: Bytes, 
+        payload: Bytes, 
+        signature: Bytes
+    )?
+
     /// Creates a JWT with custom headers and payload
     ///
     /// - parameter headers:  Headers object as Node
@@ -37,6 +45,7 @@ public struct JWT {
         let message = encoded.joined(separator: JWT.separator)
         let bytes = try signer.sign(message: message.bytes)
         signature = try encoding.encode(bytes)
+        rawToken = nil
     }
 
     /// Creates a JWT with claims and default headers ("typ", and "alg")
@@ -87,6 +96,12 @@ public struct JWT {
         payload = try encoding.decode(segments[1])
         signature = segments[2]
         self.encoding = encoding
+
+        self.rawToken = (
+            segments[0].makeBytes(),
+            segments[1].makeBytes(),
+            segments[2].makeBytes()
+        )
     }
 
     /// Creates a token from the provided header and payload (claims), encoded using the JWT's 
@@ -112,6 +127,12 @@ extension JWT: SignatureVerifiable {
     }
 
     public func createMessage() throws -> Bytes {
+        if let rawToken = self.rawToken {
+            return rawToken.header 
+                + JWT.separator.makeBytes() 
+                + rawToken.payload
+        }
+
         return try [headers, payload]
             .map(encoding.encode)
             .joined(separator: JWT.separator)

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -98,9 +98,9 @@ public struct JWT {
         self.encoding = encoding
 
         self.rawToken = (
-            segments[0].makeBytes(),
-            segments[1].makeBytes(),
-            segments[2].makeBytes()
+            try segments[0].makeBytes(),
+            try segments[1].makeBytes(),
+            try segments[2].makeBytes()
         )
     }
 
@@ -127,9 +127,10 @@ extension JWT: SignatureVerifiable {
     }
 
     public func createMessage() throws -> Bytes {
+        let separator = try JWT.separator.makeBytes()
         if let rawToken = self.rawToken {
             return rawToken.header 
-                + JWT.separator.makeBytes() 
+                + separator
                 + rawToken.payload
         }
 

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -107,6 +107,12 @@ final class JWTTests: XCTestCase {
         try jwt.verifyClaims([])
     }
 
+    func testHS256VerificationOfWellKnownToken() throws {
+        let jwt = try JWT(token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE0ODkwMDE0MzIsImV4cCI6MTUyMDUzODA4NCwiYXVkIjoiIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImFkbWluIjoidHJ1ZSJ9.wvd76NP4xKMPEL0Knu0l2mi-fZPiPW49o1nsP2aMSeo")
+
+        try jwt.verifySignature(using: HS256(key: "foobar".bytes))
+    }
+
     static let all = [
         ("testSignature", testSignature),
         ("testInitWithToken", testInitWithToken),
@@ -115,5 +121,6 @@ final class JWTTests: XCTestCase {
         ("testCustomHeaders", testCustomHeaders),
         ("testCustomJSONHeaders", testCustomJSONHeaders),
         ("testJWTClaimsCanBeVerified", testJWTClaimsCanBeVerified),
+        ("testHS256VerificationOfWellKnownToken", testHS256VerificationOfWellKnownToken)
     ]
 }

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -114,7 +114,7 @@ final class JWTTests: XCTestCase {
             encoding: Base64URLEncoding()
         )
 
-        let signer = HS256(key: "foobar".makeBytes())
+        let signer = HS256(key: try "foobar".makeBytes())
         try jwt.verifySignature(using: signer)
     }
 

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -55,7 +55,8 @@ final class JWTTests: XCTestCase {
         let token = "{\"alg\":\"tilde\"}.[\"payload\"].~{\"alg\":\"tilde\"},[\"payload\"]~"
         let jwt = try JWT(
             token: token,
-            encoding: PeriodToCommaEncoding())
+            encoding: PeriodToCommaEncoding()
+        )
         XCTAssertEqual(jwt.algorithmName, "tilde")
         XCTAssertEqual(try jwt.createToken(), token)
         try jwt.verifySignature(using: TildeSigner())
@@ -108,9 +109,13 @@ final class JWTTests: XCTestCase {
     }
 
     func testHS256VerificationOfWellKnownToken() throws {
-        let jwt = try JWT(token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE0ODkwMDE0MzIsImV4cCI6MTUyMDUzODA4NCwiYXVkIjoiIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImFkbWluIjoidHJ1ZSJ9.wvd76NP4xKMPEL0Knu0l2mi-fZPiPW49o1nsP2aMSeo")
+        let jwt = try JWT(
+            token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE0ODkwMDE0MzIsImV4cCI6MTUyMDUzODA4NCwiYXVkIjoiIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImFkbWluIjoidHJ1ZSJ9.wvd76NP4xKMPEL0Knu0l2mi-fZPiPW49o1nsP2aMSeo=",
+            encoding: Base64URLEncoding()
+        )
 
-        try jwt.verifySignature(using: HS256(key: "foobar".bytes))
+        let signer = HS256(key: "foobar".makeBytes())
+        try jwt.verifySignature(using: signer)
     }
 
     static let all = [


### PR DESCRIPTION
- Base64URL encoding by default https://github.com/vapor/jwt/commit/0a27d2847a6f3d872591cea8b5fe4dc477f17bd9
- raw token verification https://github.com/vapor/jwt/commit/c326e78fe112bde8efbf001c625a24c86ffc730d