### PR TITLE
Fix signature verification, set Base64url as default encoding

### DIFF
--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -54,17 +54,15 @@ final class JWTTests: XCTestCase {
         }
     }
 
-    func testInitWithToken() {
-        do {
-            let token = "{\"alg\":\"tilde\"}.[\"payload\"].~{\"alg\":\"tilde\"},[\"payload\"]~"
-            let jwt = try JWT(token: token,
-                          encoding: PeriodToCommaEncoding())
-            XCTAssertEqual(jwt.algorithmName, "tilde")
-            XCTAssertEqual(try jwt.createToken(), token)
-            try jwt.verifySignature(using: TildeSigner())
-        } catch {
-            XCTFail("\(error)")
-        }
+    func testInitWithToken() throws {
+        let token = "{\"alg\":\"tilde\"}.[\"payload\"].~{\"alg\":\"tilde\"},[\"payload\"]~"
+        let jwt = try JWT(
+            token: token,
+            encoding: PeriodToCommaEncoding()
+        )
+        XCTAssertEqual(jwt.algorithmName, "tilde")
+        XCTAssertEqual(try jwt.createToken(), token)
+        try jwt.verifySignature(using: TildeSigner())
     }
 
     func testIncorrectNumberOfSegments() {
@@ -122,6 +120,16 @@ final class JWTTests: XCTestCase {
         }
     }
 
+    func testHS256VerificationOfWellKnownToken() throws {
+        let jwt = try JWT(
+            token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE0ODkwMDE0MzIsImV4cCI6MTUyMDUzODA4NCwiYXVkIjoiIiwic3ViIjoiMTIzNDU2Nzg5MCIsIm5hbWUiOiJKb2huIERvZSIsImFkbWluIjoidHJ1ZSJ9.wvd76NP4xKMPEL0Knu0l2mi-fZPiPW49o1nsP2aMSeo=",
+            encoding: Base64URLEncoding()
+        )
+
+        let signer = HS256(key: try "foobar".makeBytes())
+        try jwt.verifySignature(using: signer)
+    }
+
     static let all = [
         ("testSignature", testSignature),
         ("testInitWithToken", testInitWithToken),
@@ -130,5 +138,6 @@ final class JWTTests: XCTestCase {
         ("testCustomHeaders", testCustomHeaders),
         ("testCustomJSONHeaders", testCustomJSONHeaders),
         ("testJWTClaimsCanBeVerified", testJWTClaimsCanBeVerified),
+        ("testHS256VerificationOfWellKnownToken", testHS256VerificationOfWellKnownToken)
     ]
 }


### PR DESCRIPTION
Backport of #32, starting again from the proper base commit to avoid breakage.

This time I branched vapor-1 off 0.8.0+some README fixes, so it should not break existing projects. Please help me by triple-check it.