### PR TITLE
X509 certs support

### DIFF
--- a/Sources/JWT/Signers/RSASigner+X509.swift
+++ b/Sources/JWT/Signers/RSASigner+X509.swift
@@ -17,7 +17,10 @@ extension RSAKey {
         }
 
         // free resources
-        EVP_PKEY_free(pubkey)
+        defer {
+            X509_free(cert)
+            EVP_PKEY_free(pubkey)
+        }
 
         self = .public(rsa)
     }

--- a/Sources/JWT/Signers/RSASigner+X509.swift
+++ b/Sources/JWT/Signers/RSASigner+X509.swift
@@ -10,16 +10,24 @@ extension RSAKey {
                 let count = cert.count
 
                 return d2i_X509(nil, &base, count)
-            }),
-            let pubkey = X509_get_pubkey(cert),
-            let rsa = EVP_PKEY_get1_RSA(pubkey) else {
+            }) else {
                 throw JWTError.createPublicKey
         }
 
-        // free resources
         defer {
             X509_free(cert)
+        }
+
+        guard let pubkey = X509_get_pubkey(cert) else {
+            throw JWTError.createPublicKey
+        }
+
+        defer {
             EVP_PKEY_free(pubkey)
+        }
+
+        guard let rsa = EVP_PKEY_get1_RSA(pubkey) else {
+            throw JWTError.createPublicKey
         }
 
         self = .public(rsa)

--- a/Sources/JWT/Signers/RSASigner+X509.swift
+++ b/Sources/JWT/Signers/RSASigner+X509.swift
@@ -1,0 +1,30 @@
+import CTLS
+
+typealias CX509Key = UnsafeMutablePointer<X509>
+
+extension RSAKey {
+    public init(x509Cert cert: Bytes) throws {
+        guard
+            let cert = cert.withUnsafeBufferPointer({ rawKeyPointer -> CX509Key? in
+                var base = rawKeyPointer.baseAddress
+                let count = cert.count
+
+                return d2i_X509(nil, &base, count)
+            }),
+            let pubkey = X509_get_pubkey(cert),
+            let rsa = EVP_PKEY_get1_RSA(pubkey) else {
+                throw JWTError.createPublicKey
+        }
+
+        // free resources
+        EVP_PKEY_free(pubkey)
+
+        self = .public(rsa)
+    }
+}
+
+extension RSASigner {
+    public init(x509Cert: Bytes) throws {
+        try self.init(rsaKey: RSAKey(x509Cert: x509Cert))
+    }
+}

--- a/Tests/JWTTests/SignerTests.swift
+++ b/Tests/JWTTests/SignerTests.swift
@@ -103,7 +103,7 @@ final class SignerTests: XCTestCase {
 
     func testRS256() throws {
         try checkSigner(
-            createSigner: RS256.init,
+            createSigner: RS256.init(key:),
             name: "RS256",
             privateKey: privateRSAKey,
             publicKey: publicRSAKey
@@ -112,7 +112,7 @@ final class SignerTests: XCTestCase {
 
     func testRS384() throws {
         try checkSigner(
-            createSigner: RS384.init,
+            createSigner: RS384.init(key:),
             name: "RS384",
             privateKey: privateRSAKey,
             publicKey: publicRSAKey
@@ -121,7 +121,7 @@ final class SignerTests: XCTestCase {
 
     func testRS512() throws {
         try checkSigner(
-            createSigner: RS512.init,
+            createSigner: RS512.init(key:),
             name: "RS512",
             privateKey: privateRSAKey,
             publicKey: publicRSAKey
@@ -141,6 +141,37 @@ final class SignerTests: XCTestCase {
         }
     }
 
+    let privateKeyX509 = "MIIBOgIBAAJBAPnZE7Om9gDGaYgC5bszVridpL/6LeSPPxaDc3/wa+HNzydMjpxfmDMxg8hdCfMuhGyQLtqNqfIAK2oL7x20APkCAwEAAQJAa0w3ctLEGScckSW1ZUSx/IzvAOc/KEYAcPm483vbyNeR3wrwRWl3ZkNy+z1pr+ND1tnVYpHKEdzlMOUOY+5TNQIhAP/OBHEH/fQCd4dPExG1WwPVsIqHvxtvc+f+NY4qHisPAiEA+gnlS+IGcKED1RnhRznvAqYDDKzmEo5hvX9M0i9GM3cCIAuJs1GV1rKG2fVUb7vAvlYx8UCOVuRZ5pR0Nt4usCWpAiAHJ09TG3VZtZGZgDMMyaCH7934d93hPAeZ11GIVefpQwIhAN9cZc9wZDUdz6/2+pXpdozzbXcowWZZbID+FDdclQ9/"
+    let publicCert = "MIICWTCCAgOgAwIBAgIJANM5K91tjScPMA0GCSqGSIb3DQEBCwUAMFQxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTcwNTIyMDMxMDI2WhcNMTcwNjIxMDMxMDI2WjBUMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzANBgNVBAcTBkRlbnZlcjEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAPnZE7Om9gDGaYgC5bszVridpL/6LeSPPxaDc3/wa+HNzydMjpxfmDMxg8hdCfMuhGyQLtqNqfIAK2oL7x20APkCAwEAAaOBtzCBtDAdBgNVHQ4EFgQUJoHhyknL7sHyLZMR+EbDLWPTaYEwgYQGA1UdIwR9MHuAFCaB4cpJy+7B8i2TEfhGwy1j02mBoVikVjBUMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzANBgNVBAcTBkRlbnZlcjEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkggkA0zkr3W2NJw8wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAAAkIvlASbRx7ORKYNixdpUw8tHdFRlzcQJ/QHCZAjOqvDp7jPmMrUwIDjHGOfSiWgU2bd2tljnzp5HVdqahzWA="
+
+    func checkSignerX590(
+        createSigner: (Bytes) throws -> Signer,
+        createVerifier: (Bytes) throws -> Signer,
+        name: String,
+        message: String = "message",
+        privateKey: String,
+        publicKey: String,
+        file: StaticString = #file,
+        line: UInt = #line
+
+    ) throws {
+        let signer = try createSigner(privateKeyX509.makeBytes().base64URLDecoded)
+        let verifier = try createVerifier(publicCert.makeBytes().base64URLDecoded)
+        XCTAssertEqual(signer.name, name, file: file, line: line)
+        let signature = try signer.sign(message: message.makeBytes())
+        try verifier.verify(signature: signature, message: message.makeBytes())
+    }
+
+    func testRS512x256() throws {
+        try checkSignerX590(
+            createSigner: RS256.init(key:),
+            createVerifier: RS256.init(x509Cert:),
+            name: "RS256",
+            privateKey: privateKeyX509,
+            publicKey: publicCert
+        )
+    }
+
     static let all = [
         ("testUnsigned", testUnsigned),
         ("testHS256", testHS256),
@@ -152,5 +183,6 @@ final class SignerTests: XCTestCase {
         ("testRS256", testRS256),
         ("testRS384", testRS384),
         ("testRS512", testRS512),
+        ("testRS512x256", testRS512x256),
     ]
 }

--- a/Tests/JWTTests/SignerTests.swift
+++ b/Tests/JWTTests/SignerTests.swift
@@ -155,14 +155,14 @@ final class SignerTests: XCTestCase {
         line: UInt = #line
 
     ) throws {
-        let signer = try createSigner(privateKeyX509.makeBytes().base64URLDecoded)
-        let verifier = try createVerifier(publicCert.makeBytes().base64URLDecoded)
+        let signer = try createSigner(privateKey.makeBytes().base64URLDecoded)
+        let verifier = try createVerifier(publicKey.makeBytes().base64URLDecoded)
         XCTAssertEqual(signer.name, name, file: file, line: line)
         let signature = try signer.sign(message: message.makeBytes())
         try verifier.verify(signature: signature, message: message.makeBytes())
     }
 
-    func testRS512x256() throws {
+    func testRS256x509() throws {
         try checkSignerX590(
             createSigner: RS256.init(key:),
             createVerifier: RS256.init(x509Cert:),
@@ -183,6 +183,6 @@ final class SignerTests: XCTestCase {
         ("testRS256", testRS256),
         ("testRS384", testRS384),
         ("testRS512", testRS512),
-        ("testRS512x256", testRS512x256),
+        ("testRS256x509", testRS256x509),
     ]
 }

--- a/Tests/JWTTests/SignerTests.swift
+++ b/Tests/JWTTests/SignerTests.swift
@@ -54,6 +54,7 @@ final class SignerTests: XCTestCase {
 
     func checkSigner(
         createSigner: (Bytes) throws -> Signer,
+        createVerifier: ((Bytes) throws -> Signer)? = nil,
         name: String,
         message: String = "message",
         privateKey: String,
@@ -63,7 +64,10 @@ final class SignerTests: XCTestCase {
 
     ) throws {
         let signer = try createSigner(privateKey.makeBytes().base64URLDecoded)
-        let verifier = try createSigner(publicKey.makeBytes().base64URLDecoded)
+
+        let publicBytes = publicKey.makeBytes().base64URLDecoded
+        let verifier = try createVerifier?(publicBytes) ?? createSigner(publicBytes)
+
         XCTAssertEqual(signer.name, name, file: file, line: line)
 
         let signature = try signer.sign(message: message.makeBytes())
@@ -144,26 +148,8 @@ final class SignerTests: XCTestCase {
     let privateKeyX509 = "MIIBOgIBAAJBAPnZE7Om9gDGaYgC5bszVridpL/6LeSPPxaDc3/wa+HNzydMjpxfmDMxg8hdCfMuhGyQLtqNqfIAK2oL7x20APkCAwEAAQJAa0w3ctLEGScckSW1ZUSx/IzvAOc/KEYAcPm483vbyNeR3wrwRWl3ZkNy+z1pr+ND1tnVYpHKEdzlMOUOY+5TNQIhAP/OBHEH/fQCd4dPExG1WwPVsIqHvxtvc+f+NY4qHisPAiEA+gnlS+IGcKED1RnhRznvAqYDDKzmEo5hvX9M0i9GM3cCIAuJs1GV1rKG2fVUb7vAvlYx8UCOVuRZ5pR0Nt4usCWpAiAHJ09TG3VZtZGZgDMMyaCH7934d93hPAeZ11GIVefpQwIhAN9cZc9wZDUdz6/2+pXpdozzbXcowWZZbID+FDdclQ9/"
     let publicCert = "MIICWTCCAgOgAwIBAgIJANM5K91tjScPMA0GCSqGSIb3DQEBCwUAMFQxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhDb2xvcmFkbzEPMA0GA1UEBxMGRGVudmVyMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTcwNTIyMDMxMDI2WhcNMTcwNjIxMDMxMDI2WjBUMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzANBgNVBAcTBkRlbnZlcjEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAPnZE7Om9gDGaYgC5bszVridpL/6LeSPPxaDc3/wa+HNzydMjpxfmDMxg8hdCfMuhGyQLtqNqfIAK2oL7x20APkCAwEAAaOBtzCBtDAdBgNVHQ4EFgQUJoHhyknL7sHyLZMR+EbDLWPTaYEwgYQGA1UdIwR9MHuAFCaB4cpJy+7B8i2TEfhGwy1j02mBoVikVjBUMQswCQYDVQQGEwJVUzERMA8GA1UECBMIQ29sb3JhZG8xDzANBgNVBAcTBkRlbnZlcjEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkggkA0zkr3W2NJw8wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAAAkIvlASbRx7ORKYNixdpUw8tHdFRlzcQJ/QHCZAjOqvDp7jPmMrUwIDjHGOfSiWgU2bd2tljnzp5HVdqahzWA="
 
-    func checkSignerX590(
-        createSigner: (Bytes) throws -> Signer,
-        createVerifier: (Bytes) throws -> Signer,
-        name: String,
-        message: String = "message",
-        privateKey: String,
-        publicKey: String,
-        file: StaticString = #file,
-        line: UInt = #line
-
-    ) throws {
-        let signer = try createSigner(privateKey.makeBytes().base64URLDecoded)
-        let verifier = try createVerifier(publicKey.makeBytes().base64URLDecoded)
-        XCTAssertEqual(signer.name, name, file: file, line: line)
-        let signature = try signer.sign(message: message.makeBytes())
-        try verifier.verify(signature: signature, message: message.makeBytes())
-    }
-
     func testRS256x509() throws {
-        try checkSignerX590(
+        try checkSigner(
             createSigner: RS256.init(key:),
             createVerifier: RS256.init(x509Cert:),
             name: "RS256",


### PR DESCRIPTION
The code I added allows the lib to support verify JWTs with X509 certificates.

For example, the keys provided by Google for verifying Firebase tokens.
https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com


Several things first, I'm new to Swift and SSL. 


What that means:
The tests are broken and this is somewhat incomplete because I'm not sure of the most Swift-like way to implement this functionality into your library.

- Should I have put the things I added into a new file? 
- Should I have just made a function that spits out a ready-to-go RS256 when given an X509 cert?
- Does my d2i_X509 call leak memory since the `cert` it returns is never freed?
- Should I throw out an error instead of throwing a `JWTError.createPublicKey`?