### PR TITLE
Specify dateDecodingStrategy for JSON encoders/decoders

### DIFF
--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -41,9 +41,12 @@ public struct JWT<Payload> where Payload: JWTPayload {
             throw JWTError(identifier: "invalidSignature", reason: "Invalid JWT signature")
         }
 
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+
         let base64 = Base64Decoder(encoding: .base64url)
-        self.header = try JSONDecoder().decode(JWTHeader.self, from:  base64.decode(data: headerData))
-        self.payload = try JSONDecoder().decode(Payload.self, from: base64.decode(data: payloadData))
+        self.header = try jsonDecoder.decode(JWTHeader.self, from:  base64.decode(data: headerData))
+        self.payload = try jsonDecoder.decode(Payload.self, from: base64.decode(data: payloadData))
         try payload.verify()
     }
 
@@ -58,8 +61,11 @@ public struct JWT<Payload> where Payload: JWTPayload {
         let payloadData = Data(parts[1])
         let signatureData = Data(parts[2])
 
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+
         let base64 = Base64Decoder(encoding: .base64url)
-        let header = try JSONDecoder().decode(JWTHeader.self, from:  base64.decode(data: headerData))
+        let header = try jsonDecoder.decode(JWTHeader.self, from:  base64.decode(data: headerData))
         guard let kid = header.kid else {
             throw JWTError(identifier: "missingKID", reason: "`kid` header property required to identify signer")
         }
@@ -70,7 +76,7 @@ public struct JWT<Payload> where Payload: JWTPayload {
         }
 
         self.header = header
-        self.payload = try JSONDecoder().decode(Payload.self, from: base64.decode(data: payloadData))
+        self.payload = try jsonDecoder.decode(Payload.self, from: base64.decode(data: payloadData))
         try payload.verify()
     }
 
@@ -84,9 +90,12 @@ public struct JWT<Payload> where Payload: JWTPayload {
         let headerData = Data(parts[0])
         let payloadData = Data(parts[1])
 
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .secondsSince1970
+
         let base64 = Base64Decoder(encoding: .base64url)
-        self.header = try JSONDecoder().decode(JWTHeader.self, from:  base64.decode(data: headerData))
-        self.payload = try JSONDecoder().decode(Payload.self, from: base64.decode(data: payloadData))
+        self.header = try jsonDecoder.decode(JWTHeader.self, from:  base64.decode(data: headerData))
+        self.payload = try jsonDecoder.decode(Payload.self, from: base64.decode(data: payloadData))
     }
 
     /// Signs the message and returns the serialized JSON web token

--- a/Sources/JWT/JWTSigner.swift
+++ b/Sources/JWT/JWTSigner.swift
@@ -24,11 +24,14 @@ public final class JWTSigner {
     /// let signedString = String(bytes: signed, encoding: .utf8)
     /// ```
     public func sign<Payload>(_ jwt: inout JWT<Payload>) throws -> Data {
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.dateEncodingStrategy = .secondsSince1970
+
         jwt.header.alg = self.algorithm.jwtAlgorithmName
-        let headerData = try JSONEncoder().encode(jwt.header)
+        let headerData = try jsonEncoder.encode(jwt.header)
         let encodedHeader = base64.encode(data: headerData)
 
-        let payloadData = try JSONEncoder().encode(jwt.payload)
+        let payloadData = try jsonEncoder.encode(jwt.payload)
         let encodedPayload = base64.encode(data: payloadData)
 
         let encodedSignature = try signature(header: encodedHeader, payload: encodedPayload)


### PR DESCRIPTION
This pull request specifies which date encoding/decoding strategies should be used. According to the [spec](https://tools.ietf.org/html/rfc7519#section-2), JWT dates should be represented by seconds since the epoch.