### PR TITLE
rsa

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
         .library(name: "JWT", targets: ["JWT"]),
     ],
     dependencies: [
-        // Cryptography modules
-        .package(url: "https://github.com/vapor/crypto.git", "3.0.0-beta.1"..<"3.0.0-beta.2"),
+        // 🔑 Hashing (BCrypt, SHA, HMAC, etc), encryption, and randomness.
+        .package(url: "https://github.com/vapor/crypto.git", from: "3.0.0-rc"),
     ],
     targets: [
         .target(name: "JWT", dependencies: ["Crypto"]),

--- a/Sources/JWT/JWT.swift
+++ b/Sources/JWT/JWT.swift
@@ -37,7 +37,7 @@ public struct JWT<Payload> where Payload: JWTPayload {
         let payloadData = Data(parts[1])
         let signatureData = Data(parts[2])
 
-        guard try signer.signature(header: headerData, payload: payloadData) == signatureData else {
+        guard try signer.verify(signatureData, header: headerData, payload: payloadData) else {
             throw JWTError(identifier: "invalidSignature", reason: "Invalid JWT signature")
         }
 
@@ -71,7 +71,7 @@ public struct JWT<Payload> where Payload: JWTPayload {
         }
 
         let signer = try signers.requireSigner(kid: kid)
-        guard try signer.signature(header: headerData, payload: payloadData) == signatureData else {
+        guard try signer.verify(signatureData, header: headerData, payload: payloadData) else {
             throw JWTError(identifier: "invalidSignature", reason: "Invalid JWT signature")
         }
 

--- a/Sources/JWT/JWTSigner.swift
+++ b/Sources/JWT/JWTSigner.swift
@@ -30,7 +30,6 @@ public final class JWTSigner {
     public func sign<Payload>(_ jwt: inout JWT<Payload>) throws -> Data {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.dateEncodingStrategy = .secondsSince1970
-
         jwt.header.alg = self.algorithm.jwtAlgorithmName
         let headerData = try jsonEncoder.encode(jwt.header)
         let encodedHeader = base64encoder.encode(data: headerData)

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import JWT
+import Crypto
 
 class JWTTests: XCTestCase {
     func testParse() throws {
@@ -52,6 +53,30 @@ class JWTTests: XCTestCase {
         let jwt = try! JWT<TestPayload>(from: data, verifiedUsing: signers)
         XCTAssertEqual(jwt.payload.name, "John Doe")
     }
+
+    func testRSA() throws {
+        let privateKey = try Base64Decoder(encoding: .base64).decode(string: privateKeyString)
+        let publicKey = try Base64Decoder(encoding: .base64).decode(string: publicKeyString)
+        let privateSigner = JWTSigner.rs256(key: .private2048(privateKey))
+        let publicSigner = JWTSigner.rs256(key: .public2048(publicKey))
+
+        let payload = TestPayload(
+            sub: "vapor",
+            name: "Foo",
+            admin: false,
+            exp: .init(value: .init(timeIntervalSince1970: 2_000_000_000))
+        )
+        var jwt = JWT(payload: payload)
+        do {
+            _ = try jwt.sign(using: publicSigner)
+            XCTFail("cannot sign with public signer")
+        } catch {
+            // pass
+        }
+        let data = try jwt.sign(using: privateSigner)
+        let parsed = try JWT<TestPayload>(from: data, verifiedUsing: privateSigner)
+        XCTAssertEqual(parsed.payload.name, "Foo")
+    }
     
     static var allTests = [
         ("testParse", testParse),
@@ -59,6 +84,7 @@ class JWTTests: XCTestCase {
         ("testExpirationDecoding", testExpirationDecoding),
         ("testExpirationEncoding", testExpirationEncoding),
         ("testSigners", testSigners),
+        ("testRSA", testRSA),
     ]
 }
 
@@ -80,3 +106,44 @@ struct ExpirationPayload: JWTPayload {
         try exp.verify()
     }
 }
+
+/// MARK: RSA
+
+let privateKeyString = """
+MIIEpAIBAAKCAQEAk+dWlCTQIr85rtUi56yD6FT6vuG68Q9xJ4B9bAo4wys+ndlP
+SX0UQkrPOpnNZcsHOob6DbRI5Cc4qce00nNJAlCxYqAJDDDryyQEtUv8ghGGWnjU
+gBRytm39UM9s/UxyLfGWk3P1Z1us8q5RvsrceC28uG94Lr+w2XmcBwxP020qJIiU
+qOff8me1vI7vogvec3yO6pLvb1zcqMioKIdQ/kWjgMvhVyFyg44IqEI1iApjt05C
+jTQ30W1xyN/9b/cedQzEg8Nq2MQdhKCIZJh2vjSUuWOBCnx+ttErIYt0roisNj1O
+howtSM6k0vV1LPDrCjV7lFPmE1njwTfdV/vlcQIDAQABAoIBAGBwjt6oJmMRx139
+sfXYYmZiyuEeNRQsGn9EZAPHon14PCsW4IEtosEbIIa4dNq0CPGbw36eGI1UGbly
+86/p5igxT4jciym82HMr+Dny4yI4pR9m/EDLlITpsSw5JHsBls3oYmOhT9nmSB4x
+ljHO+vUN9alZXcc1zO3xQtDBsWdNG73YFRAv2HJ6us50wQXw4cEsuQo6X/fUREkB
+nznkArTcm/VcnZFaRUg4sXQBBQdy3LhRh3zQ5V64iBe9AWgenDv7tO5Bk8xhrLE/
+kBdvyrTsWKaKSSnes28oB5YLfbFpRYnYGGuaWbu5f0deOuQlS5F5HxuaHHsdRxaU
+Xee7BLECgYEA60QxWsXdeIWXmMhOoCapq6OTdaPVVzZfZc57s82xy5IgghBJj3up
+QbOIcfcBNTmpG4ohtB5EEmOozBKEm3dg09RF9aQ/t4Gx4TOmbtCt8IiuNAr4zj7+
+xsLWh1sWGK0UvZ1hkkKoFxHU7ienXCfhfiEjBLWtNGzVHieoIc1Ly00CgYEAoPAr
+Txegn2ZreU4vn6CP9pHIxY6JV7nFPbGng6q8hkMMCu7CY/w9UP9iZG6uvQcoSqGt
+7rIUUqYWUcf8qcAtvWyLTZmtkCm+LIHiJak4PZXwTrpYOZQScpBTw8ViuVREsJSw
+5oHgworZg3rD9oLbiSt+Iy//U14g7gzA7mJVyLUCgYEA6pHoX6gOpH8WYme9NSK3
+YwHKIa4DJVx6C2ivn9uD3QPKU8PnhB746CAX+AEd/DKMcH/uEMdoealSAH6qJtQE
+/8+THVLxkIbIk1BLLgv0kXHFtvAFmKXoosZa3UQtKNdRaakEQq8hJzdJRVbWICVH
+R9nEL4rwseedKd7CXUlyu7UCgYBrjnbzQfAn95QGGxm6zdzIxb9vQIZLaa0HQS6Z
+0UZzWGW4/L5Pgikcc8E3K71+OUVVM16BsuPgJH2wJD6Y2AX5nYwvzW/wc+VT623P
+C5u5lPZoNyN1P59gj1Jb+RO0ljvd41Gii9RBT/h0ZVyH6AZ+UuHW9GHoPnU1grKB
+3phELQKBgQDOWrOLmd/v43r99fxqrkZv9twFkAPlcpYOMn/SDpmJfWR3sGWCz5eI
+czQFrr4k36C5HwgornNShezXpbU9bGaG7zAdd3egdqjYeWQeqj/WQFAoP6+jA+yL
+hR/bpssdZZaF7Ah0AR/IHGgbNLAfdpGBjyEl1WRoq+tuJ9oMcbKezQ==
+""".replacingOccurrences(of: "\n", with: "")
+
+let publicKeyString = """
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk+dWlCTQIr85rtUi56yD
+6FT6vuG68Q9xJ4B9bAo4wys+ndlPSX0UQkrPOpnNZcsHOob6DbRI5Cc4qce00nNJ
+AlCxYqAJDDDryyQEtUv8ghGGWnjUgBRytm39UM9s/UxyLfGWk3P1Z1us8q5Rvsrc
+eC28uG94Lr+w2XmcBwxP020qJIiUqOff8me1vI7vogvec3yO6pLvb1zcqMioKIdQ
+/kWjgMvhVyFyg44IqEI1iApjt05CjTQ30W1xyN/9b/cedQzEg8Nq2MQdhKCIZJh2
+vjSUuWOBCnx+ttErIYt0roisNj1OhowtSM6k0vV1LPDrCjV7lFPmE1njwTfdV/vl
+cQIDAQAB
+""".replacingOccurrences(of: "\n", with: "")
+

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -148,4 +148,3 @@ eC28uG94Lr+w2XmcBwxP020qJIiUqOff8me1vI7vogvec3yO6pLvb1zcqMioKIdQ
 vjSUuWOBCnx+ttErIYt0roisNj1OhowtSM6k0vV1LPDrCjV7lFPmE1njwTfdV/vl
 cQIDAQAB
 """.replacingOccurrences(of: "\n", with: "")
-

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -73,9 +73,11 @@ class JWTTests: XCTestCase {
         } catch {
             // pass
         }
-        let data = try jwt.sign(using: privateSigner)
-        let parsed = try JWT<TestPayload>(from: data, verifiedUsing: privateSigner)
-        XCTAssertEqual(parsed.payload.name, "Foo")
+        let privateSigned = try jwt.sign(using: privateSigner)
+        let publicVerified = try JWT<TestPayload>(from: privateSigned, verifiedUsing: publicSigner)
+        let privateVerified = try JWT<TestPayload>(from: privateSigned, verifiedUsing: privateSigner)
+        XCTAssertEqual(publicVerified.payload.name, "Foo")
+        XCTAssertEqual(privateVerified.payload.name, "Foo")
     }
     
     static var allTests = [

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -38,9 +38,10 @@ class JWTTests: XCTestCase {
         var jwt = JWT(payload: ExpirationPayload(exp: exp))
 
         let signer = JWTSigner.hs256(key: Data("secret".utf8))
+        jwt.header.typ = nil // set to nil to avoid dictionary re-ordering causing probs
         let data = try signer.sign(&jwt)
 
-        XCTAssertEqual(String(data: data, encoding: .utf8), "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjIwMDAwMDAwMDB9.JgCO_GqUQnbS0z2hCxJLE9Tpt5SMoZObHBxzGBWuTYQ")
+        XCTAssertEqual(String(data: data, encoding: .utf8), "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjIwMDAwMDAwMDB9.4W6egHvMSp9bBiGUnE7WhVfXazOfg-ADcjvIYILgyPU")
     }
 
     func testSigners() throws {


### PR DESCRIPTION
- [x] adds `RS256`, `RS384`, and `RS512` signature support to JWT

```swift
// create public and private key (only public required for verification)
let privateKey: Data = ...
let publicKey: Data = ...
let privateSigner = JWTSigner.rs256(key: .private2048(privateKey))
let publicSigner = JWTSigner.rs256(key: .public2048(publicKey))

// serialize jwt (requires private key)
let payload: TestPayload = ...
var jwt = JWT(payload: payload)
_ = try jwt.sign(using: publicSigner) // throws, can't sign w/ public signer
let data = try jwt.sign(using: privateSigner)

// parse jwt (public and private key work)
let parsed = try JWT<TestPayload>(from: data, verifiedUsing: publicSigner)
let parsed2 = try JWT<TestPayload>(from: data, verifiedUsing: privateSigner) // also works
print(parsed.payload)
print(parsed2.payload)
```

Fixes #81 