### PR TITLE
[Do not merge] Add test to show concurrency issue with HMAC

### DIFF
--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -90,7 +90,7 @@ class JWTTests: XCTestCase {
 
         let signer: JWTSigner = .hs256(key: "secret-access")
 
-        for _ in 0..<2 {
+        for _ in 0..<1000 {
             queue.async(group: group) {
                 group.enter()
 


### PR DESCRIPTION
This branch show some serious problems with concurrent HMAC verification. It can fail in a number of ways:
- `EXC_BAD_ACCESS` in:
  - `HMAC.finish`
  - `HMAC.reset`
- failed verification even though it should pass
- ``libsystem_kernel.dylib`__ulock_wait:``

When using a serial queue the problem goes away.

The underlying issue is probably better addressed in GitHub.com/vapor/crypto but it was easier to reproduce here.