### PR TITLE
Add JWKSCache helper for storing JWKS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,8 +10,8 @@ let package = Package(
         .library(name: "JWT", targets: ["JWT"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0-beta.2"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.2"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0-beta.2.3"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.3.17"),
     ],
     targets: [
         .target(name: "JWT", dependencies: ["JWTKit", "Vapor"]),

--- a/Sources/JWT/JWKSCache.swift
+++ b/Sources/JWT/JWKSCache.swift
@@ -1,0 +1,86 @@
+import Vapor
+
+/// A thread-safe and atomic class for retrieving JSON Web Key Sets which honors the
+/// HTTP `Cache-Control`, `Expires` and `Etag` headers.
+public final class JWKSCache {
+    private let uri: URI
+
+    // Uses a private event loop so that read of the cache date and the possible
+    // subsequent network download happens atomically.  Don't want multiple requests
+    // coming in at once and kicking off multiple network downloads.
+    private let eventLoop: EventLoop
+
+    internal var cacheUntil: Date?
+    internal var jwks: JWKS?
+    internal var etag: String?
+
+    /// The initializer.
+    /// - Parameters:
+    ///   - keyURL: The URL to the JWKS data.
+    ///   - application: The Vapor `Application`.
+    public init(keyURL: String, on application: Application) {
+        self.uri = URI(string: keyURL)
+        eventLoop = application.eventLoopGroup.next()
+    }
+
+    /// Downloads the JSON Web Key Set, taking into account `Cache-Control`, `Expires` and `Etag` headers..
+    /// - Parameter req: The Vapor `Request` object
+    public func keys(on req: Request) -> EventLoopFuture<JWKS> {
+        eventLoop.flatSubmit {
+            if let jwks = self.jwks, let cacheUntil = self.cacheUntil, Date() < cacheUntil {
+                return self.eventLoop.makeSucceededFuture(jwks)
+            }
+
+            let requested = Date()
+
+            var headers: HTTPHeaders = [:]
+            if let etag = self.etag {
+                headers.add(name: .ifNoneMatch, value: etag)
+            }
+
+
+            return req.client.get(self.uri, headers: headers)
+                .hop(to: self.eventLoop)
+                .flatMap { (response: ClientResponse) in
+                    let expires = response.headers.expirationDate(requestSentAt: requested)
+
+                    if response.status == .notModified {
+                        guard let jwks = self.jwks else {
+                            return self.eventLoop.makeFailedFuture(Abort(.internalServerError))
+                        }
+
+                        self.update(expires: expires, etag: self.etag, jwks: jwks)
+                    }
+
+                    guard response.status == .ok else {
+                        return self.eventLoop.makeFailedFuture(Abort(.internalServerError))
+                    }
+
+                    let decoded: JWKS
+
+                    do {
+                        decoded = try response.content.decode(JWKS.self)
+                    } catch {
+                        return self.eventLoop.makeFailedFuture(error)
+                    }
+
+                    self.update(expires: expires, etag: self.etag, jwks: decoded)
+
+                    return self.eventLoop.makeSucceededFuture(decoded)
+            }.hop(to: req.eventLoop)
+        }
+    }
+
+    private func update(expires: Date?, etag: String?, jwks: JWKS) {
+        if let expires = expires {
+            self.jwks = jwks
+            self.etag = etag
+            self.cacheUntil = expires
+        } else {
+            self.jwks = nil
+            self.etag = nil
+            self.cacheUntil = nil
+        }
+    }
+}
+

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -1,4 +1,5 @@
 import JWT
+import JWTKit
 import XCTVapor
 
 class JWTKitTests: XCTestCase {
@@ -118,6 +119,20 @@ class JWTKitTests: XCTestCase {
         }
     }
 
+    func testJWKSDownload() throws {
+        // creates a new application for testing
+        let app = Application(.testing)
+        defer { app.shutdown() }
+
+        let apple = JWKSCache(keyURL: "https://appleid.apple.com/auth/keys", on: app)
+
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        let keys = try apple.keys(on: request).wait()
+
+        let key = keys.find(identifier: "AIDOPK1", type: .rsa)
+        XCTAssertNotNil(key)
+        XCTAssertNotNil(key!.algorithm == .rs256)
+    }
 }
 
 struct LoginResponse: Content {

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -126,13 +126,13 @@ class JWTKitTests: XCTestCase {
 
         app.client.configuration.ignoreUncleanSSLShutdown = true
 
-        let apple = JWKSCache(
+        let google = JWKSCache(
             keyURL: "https://www.googleapis.com/oauth2/v3/certs",
             client: app.client
         )
 
         app.get("keys") { req in
-            apple.keys(on: req).map { jwks in
+            google.keys(on: req).map { jwks in
                 jwks.keys.count
             }
         }


### PR DESCRIPTION
Provides a way that servers can download JWKS files in response to HTTP requests such that only one request will ever be performing a download at a time.  If the remote server provides caching headers this ensures the downloads are cached appropriately.

```swift
final class RouteController {
    let apple: JWKSCache

    init(app: Application) {
        apple = .init(keyURL: "https://appleid.apple.com/auth/keys", client: app.client)
    }

    func signIn(_ req: Request) throws -> EventLoopFuture<Void> {
        apple.keys(on: req).flatMap { jwks in
            guard let key = jwks.find(identifier: "AIDOPK1", type: .rsa) else {
                return req.eventLoop.makeFailedFuture(Abort(.internalServerError))
            }

            // Use the key here
        }
    }
}
```
