### PR TITLE
Beta 3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,14 @@ import PackageDescription
 let package = Package(
     name: "jwt",
     platforms: [
-       .macOS(.v10_14)
+       .macOS(.v10_15)
     ],
     products: [
         .library(name: "JWT", targets: ["JWT"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0-beta.2.5"),
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.3.19"),
+        .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0-beta.3"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0-beta.4"),
     ],
     targets: [
         .target(name: "JWT", dependencies: ["JWTKit", "Vapor"]),


### PR DESCRIPTION
- Update OS version requirement for compatibility with latest Vapor beta.
- Major beta version bumped due to the OS version requirement being a breaking change. No changes have been made to JWT itself.