### PR TITLE
Added a public initializer to Request.JWT

### DIFF
--- a/Sources/JWT/Request+JWT.swift
+++ b/Sources/JWT/Request+JWT.swift
@@ -9,6 +9,10 @@ extension Request {
     public struct JWT {
         let request: Request
 
+        public init(request: Request) {
+            self.request = request
+        }
+
         public func verify<Payload>(as payload: Payload.Type = Payload.self) throws -> Payload
             where Payload: JWTPayload
         {


### PR DESCRIPTION
People couldn't make their own verifiers since `request` was internal.