### PR TITLE
Make JWT helpers extendable

### DIFF
--- a/Sources/JWT/Application+JWT.swift
+++ b/Sources/JWT/Application+JWT.swift
@@ -3,7 +3,7 @@ import JWTKit
 
 extension Application {
     public var jwt: JWT {
-        .init(application: self)
+        .init(_application: self)
     }
 
     public struct JWT {
@@ -18,7 +18,7 @@ extension Application {
             typealias Value = Storage
         }
 
-        let application: Application
+        public let _application: Application
 
         public var signers: JWTSigners {
             get { self.storage.signers }
@@ -26,17 +26,13 @@ extension Application {
         }
 
         private var storage: Storage {
-            if let existing = self.application.storage[Key.self] {
+            if let existing = self._application.storage[Key.self] {
                 return existing
             } else {
                 let new = Storage()
-                self.application.storage[Key.self] = new
+                self._application.storage[Key.self] = new
                 return new
             }
-        }
-
-        public init(application: Application) {
-            self.application = application
         }
     }
 }

--- a/Sources/JWT/JWT+Apple.swift
+++ b/Sources/JWT/JWT+Apple.swift
@@ -2,16 +2,16 @@ import Vapor
 
 extension Request.JWT {
     public var apple: Apple {
-        .init(request: self.request)
+        .init(_jwt: self)
     }
 
     public struct Apple {
-        let request: Request
+        public let _jwt: Request.JWT
 
         public func verify(applicationIdentifier: String? = nil) -> EventLoopFuture<AppleIdentityToken> {
-            guard let token = self.request.headers.bearerAuthorization?.token else {
-                self.request.logger.error("Request is missing JWT bearer header.")
-                return self.request.eventLoop.makeFailedFuture(Abort(.unauthorized))
+            guard let token = self._jwt._request.headers.bearerAuthorization?.token else {
+                self._jwt._request.logger.error("Request is missing JWT bearer header.")
+                return self._jwt._request.eventLoop.makeFailedFuture(Abort(.unauthorized))
             }
             return self.verify(token, applicationIdentifier: applicationIdentifier)
         }
@@ -23,11 +23,11 @@ extension Request.JWT {
         public func verify<Message>(_ message: Message, applicationIdentifier: String? = nil) -> EventLoopFuture<AppleIdentityToken>
             where Message: DataProtocol
         {
-            self.request.application.jwt.apple.signers(
-                on: self.request
+            self._jwt._request.application.jwt.apple.signers(
+                on: self._jwt._request
             ).flatMapThrowing { signers in
                 let token = try signers.verify(message, as: AppleIdentityToken.self)
-                if let applicationIdentifier = applicationIdentifier ?? self.request.application.jwt.apple.applicationIdentifier {
+                if let applicationIdentifier = applicationIdentifier ?? self._jwt._request.application.jwt.apple.applicationIdentifier {
                     try token.audience.verifyIntendedAudience(includes: applicationIdentifier)
                 }
                 return token
@@ -38,11 +38,11 @@ extension Request.JWT {
 
 extension Application.JWT {
     public var apple: Apple {
-        .init(jwt: self)
+        .init(_jwt: self)
     }
 
     public struct Apple {
-        let jwt: Application.JWT
+        public let _jwt: Application.JWT
 
         public func signers(on request: Request) -> EventLoopFuture<JWTSigners> {
             self.jwks.get(on: request).flatMapThrowing {
@@ -79,17 +79,17 @@ extension Application.JWT {
         }
 
         private var storage: Storage {
-            if let existing = self.jwt.application.storage[Key.self] {
+            if let existing = self._jwt._application.storage[Key.self] {
                 return existing
             } else {
-                let lock = self.jwt.application.locks.lock(for: Key.self)
+                let lock = self._jwt._application.locks.lock(for: Key.self)
                 lock.lock()
                 defer { lock.unlock() }
-                if let existing = self.jwt.application.storage[Key.self] {
+                if let existing = self._jwt._application.storage[Key.self] {
                     return existing
                 }
                 let new = Storage()
-                self.jwt.application.storage[Key.self] = new
+                self._jwt._application.storage[Key.self] = new
                 return new
             }
         }

--- a/Sources/JWT/Request+JWT.swift
+++ b/Sources/JWT/Request+JWT.swift
@@ -3,21 +3,17 @@ import JWTKit
 
 extension Request {
     public var jwt: JWT {
-        .init(request: self)
+        .init(_request: self)
     }
 
     public struct JWT {
-        let request: Request
-
-        public init(request: Request) {
-            self.request = request
-        }
+        public let _request: Request
 
         public func verify<Payload>(as payload: Payload.Type = Payload.self) throws -> Payload
             where Payload: JWTPayload
         {
-            guard let token = self.request.headers.bearerAuthorization?.token else {
-                self.request.logger.error("Request is missing JWT bearer header")
+            guard let token = self._request.headers.bearerAuthorization?.token else {
+                self._request.logger.error("Request is missing JWT bearer header")
                 throw Abort(.unauthorized)
             }
             return try self.verify(token, as: Payload.self)
@@ -32,13 +28,13 @@ extension Request {
         public func verify<Message, Payload>(_ message: Message, as payload: Payload.Type = Payload.self) throws -> Payload
             where Message: DataProtocol, Payload: JWTPayload
         {
-            try self.request.application.jwt.signers.verify(message, as: Payload.self)
+            try self._request.application.jwt.signers.verify(message, as: Payload.self)
         }
 
         public func sign<Payload>(_ jwt: Payload, kid: JWKIdentifier? = nil) throws -> String
             where Payload: JWTPayload
         {
-            try self.request.application.jwt.signers.sign(jwt, kid: kid)
+            try self._request.application.jwt.signers.sign(jwt, kid: kid)
         }
     }
 }


### PR DESCRIPTION
 This change publicizes internal properties on JWT helpers to make them more easily extendable (#131, fixes #125). 

```swift
// Custom extension
extension Request.JWT {
    // Methods now have access to the request
    func myVerifier() {
        print(self._request) // Current request
    }
}

// Usage
req.jwt.myVerifier()
```

The property names have been prefixed with `_` to prevent autocomplete from suggesting things like:

```swift
req.jwt.request
```

⚠️ Note: `Application.JWT` and `Request.JWT`'s initializers have been removed. These were redundant and can be declared much more concisely:

```diff
- Application.JWT(application: app)
+ app.jwt
```
```diff
- Request.JWT(request: req)
+ req.jwt
```