### PR TITLE
Allow configuration of URIs in JWT helpers

### DIFF
--- a/Sources/JWT/JWT+Apple.swift
+++ b/Sources/JWT/JWT+Apple.swift
@@ -65,15 +65,32 @@ extension Application.JWT {
             }
         }
 
+        public var jwksEndpoint: URI {
+            get {
+                self.storage.jwksEndpoint
+            }
+            nonmutating set {
+                let lock = self._jwt._application.locks.lock(for: EndpointLock.self)
+                lock.lock()
+                defer { lock.unlock() }
+                self.storage.jwksEndpoint = newValue
+                self.storage.jwks = .init(uri: newValue)
+            }
+        }
+
+        private struct EndpointLock: LockKey {}
+
         private struct Key: StorageKey, LockKey {
             typealias Value = Storage
         }
 
         private final class Storage {
-            let jwks: EndpointCache<JWKS>
+            var jwksEndpoint: URI
+            var jwks: EndpointCache<JWKS>
             var applicationIdentifier: String?
             init() {
-                self.jwks = .init(uri: "https://appleid.apple.com/auth/keys")
+                self.jwksEndpoint = "https://appleid.apple.com/auth/keys"
+                self.jwks = .init(uri: self.jwksEndpoint)
                 self.applicationIdentifier = nil
             }
         }

--- a/Sources/JWT/JWT+Microsoft.swift
+++ b/Sources/JWT/JWT+Microsoft.swift
@@ -65,15 +65,32 @@ extension Application.JWT {
             }
         }
 
+        public var jwksEndpoint: URI {
+            get {
+                self.storage.jwksEndpoint
+            }
+            nonmutating set {
+                let lock = self._jwt._application.locks.lock(for: EndpointLock.self)
+                lock.lock()
+                defer { lock.unlock() }
+                self.storage.jwksEndpoint = newValue
+                self.storage.jwks = .init(uri: newValue)
+            }
+        }
+
+        private struct EndpointLock: LockKey {}
+
         private struct Key: StorageKey, LockKey {
             typealias Value = Storage
         }
 
         private final class Storage {
-            let jwks: EndpointCache<JWKS>
+            var jwksEndpoint: URI
+            var jwks: EndpointCache<JWKS>
             var applicationIdentifier: String?
             init() {
-                self.jwks = .init(uri: "https://login.microsoftonline.com/common/discovery/keys")
+                self.jwksEndpoint = "https://login.microsoftonline.com/common/discovery/keys"
+                self.jwks = .init(uri: self.jwksEndpoint)
                 self.applicationIdentifier = nil
             }
         }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
This PR closes #134. It exposes the URIs for the JWKS endpoints in the JWT-helpers for Apple, Microsoft and Google.