### PR TITLE
Drop support for Swift 5.2 and 5.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,21 +5,8 @@ on:
     branches:
     - main
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - swift:5.4-focal
-          - swift:5.5-focal
-          - swift:5.6-focal
-    container: ${{ matrix.image }}
-    steps:
-    - uses: actions/checkout@v2
-    - run: swift test --enable-test-discovery --sanitize=thread
-  macOS:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: swift test --sanitize=thread
+  unit-tests:
+    uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+    with:
+      with_coverage: true
+      with_tsan: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,5 +8,5 @@ jobs:
   unit-tests:
     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
     with:
-      with_coverage: true
+      with_coverage: false
       with_tsan: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - swift:5.2-xenial
-          - swift:5.3-bionic
           - swift:5.4-focal
-          - swift:5.5-centos8
+          - swift:5.5-focal
+          - swift:5.6-focal
     container: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as 
announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)
