### PR TITLE
Add `@discardableResult` attribute to `verify(as:)` functions

### DIFF
--- a/Sources/JWT/Request+JWT.swift
+++ b/Sources/JWT/Request+JWT.swift
@@ -8,7 +8,8 @@ extension Request {
 
     public struct JWT {
         public let _request: Request
-
+        
+        @discardableResult
         public func verify<Payload>(as payload: Payload.Type = Payload.self) throws -> Payload
             where Payload: JWTPayload
         {
@@ -18,13 +19,15 @@ extension Request {
             }
             return try self.verify(token, as: Payload.self)
         }
-
+        
+        @discardableResult
         public func verify<Payload>(_ message: String, as payload: Payload.Type = Payload.self) throws -> Payload
             where Payload: JWTPayload
         {
             try self.verify([UInt8](message.utf8), as: Payload.self)
         }
-
+        
+        @discardableResult
         public func verify<Message, Payload>(_ message: Message, as payload: Payload.Type = Payload.self) throws -> Payload
             where Message: DataProtocol, Payload: JWTPayload
         {


### PR DESCRIPTION
Marks JWT's `verify(as:)` functions with `@discardableResult` so you can verify then without reading the contents in a clean way. For example

```swift
let _ = try req.jwt.verify(as: Payload.self)
```

Can become:

```swift
try req.jwt.verify(as: Payload.self)
```