### PR TITLE
Updating Key Collections

### DIFF
--- a/Sources/JWT/Application+JWT.swift
+++ b/Sources/JWT/Application+JWT.swift
@@ -42,7 +42,7 @@ extension Application {
 
         public var keys: JWTKeyCollection {
             get { self.storage.keys }
-            set { self.storage.keys = newValue }
+            nonmutating set { self.storage.keys = newValue }
         }
 
         private var storage: Storage {


### PR DESCRIPTION
JWT key collections (`keys`) are marked as being settable, but in practice they can't be since `jwt` is not settable. Marking `keys` as having a non mutating setting fixes this and allows the underlying storage to be updated safely.