### PR TITLE
Replace the SIWA Test

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,70 @@
+{
+  "fileScopedDeclarationPrivacy": {
+    "accessLevel": "private"
+  },
+  "indentation": {
+    "spaces": 4
+  },
+  "indentConditionalCompilationBlocks": false,
+  "indentSwitchCaseLabels": false,
+  "lineBreakAroundMultilineExpressionChainComponents": false,
+  "lineBreakBeforeControlFlowKeywords": false,
+  "lineBreakBeforeEachArgument": false,
+  "lineBreakBeforeEachGenericRequirement": false,
+  "lineLength": 140,
+  "maximumBlankLines": 1,
+  "multiElementCollectionTrailingCommas": true,
+  "noAssignmentInExpressions": {
+    "allowedFunctions": [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether": false,
+  "respectsExistingLineBreaks": true,
+  "rules": {
+    "AllPublicDeclarationsHaveDocumentation": false,
+    "AlwaysUseLiteralForEmptyCollectionInit": false,
+    "AlwaysUseLowerCamelCase": true,
+    "AmbiguousTrailingClosureOverload": true,
+    "BeginDocumentationCommentWithOneLineSummary": false,
+    "DoNotUseSemicolons": true,
+    "DontRepeatTypeInStaticProperties": true,
+    "FileScopedDeclarationPrivacy": true,
+    "FullyIndirectEnum": true,
+    "GroupNumericLiterals": true,
+    "IdentifiersMustBeASCII": true,
+    "NeverForceUnwrap": false,
+    "NeverUseForceTry": false,
+    "NeverUseImplicitlyUnwrappedOptionals": false,
+    "NoAccessLevelOnExtensionDeclaration": true,
+    "NoAssignmentInExpressions": true,
+    "NoBlockComments": true,
+    "NoCasesWithOnlyFallthrough": true,
+    "NoEmptyTrailingClosureParentheses": true,
+    "NoLabelsInCasePatterns": true,
+    "NoLeadingUnderscores": false,
+    "NoParensAroundConditions": true,
+    "NoPlaygroundLiterals": true,
+    "NoVoidReturnOnFunctionSignature": true,
+    "OmitExplicitReturns": false,
+    "OneCasePerLine": true,
+    "OneVariableDeclarationPerLine": true,
+    "OnlyOneTrailingClosureArgument": true,
+    "OrderedImports": true,
+    "ReplaceForEachWithForLoop": true,
+    "ReturnVoidInsteadOfEmptyTuple": true,
+    "TypeNamesShouldBeCapitalized": true,
+    "UseEarlyExits": false,
+    "UseExplicitNilCheckInConditions": true,
+    "UseLetInEveryBoundCaseVariable": true,
+    "UseShorthandTypeNames": true,
+    "UseSingleLinePropertyGetter": true,
+    "UseSynthesizedInitializer": true,
+    "UseTripleSlashForDocumentationComments": true,
+    "UseWhereClausesInForLoops": false,
+    "ValidateDocumentationComments": false
+  },
+  "spacesAroundRangeFormationOperators": false,
+  "tabWidth": 4,
+  "version": 1
+}

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -409,6 +409,7 @@ struct JWTTests {
                 await app.server.shutdown()
             } catch {
                 await app.server.shutdown()
+                throw error
             }
         }
     }

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -243,37 +243,163 @@ struct JWTTests {
         }
     }
 
-    // If this test expires you might need to regenerate the JWT. Use https://github.com/0xTim/vapor-jwt-test-siwa and run the project on a real device
-    // Try signing in with Apple and it will print a new JWT to use.
-    // Note that it takes a day for the JWT to expire before the test passes
-    @Test("Test Apple Authentication")
-    func testApple() async throws {
+    /// Tests the Apple Sign In verification flow using a mock JWKS endpoint.
+    /// This tests the full pipeline: JWKS fetching, token verification, and application identifier validation.
+    @Test("Test Apple Authentication with Mock JWKS")
+    func testAppleWithMockJWKS() async throws {
+        // JWKS JSON with RSA key taken from JWTKit Tests
+        let mockJWKS = """
+            {
+                "keys": [
+                    {
+                        "kty": "RSA",
+                        "kid": "test-apple-key",
+                        "use": "sig",
+                        "alg": "RS256",
+                        "n": "y_FtQ_cOcx6ZgyaqU54CESfkpttXuNnEZ07nYXXo8ylIiUFpB0r0Fecgv_tIhF1LFCWBHUsqyoSRQz0_iBRnYyIsG-yF_q1K3ll5Q_2GAS9_28jBuJGKDuKIj6dgPlr33si6bjeePTl4ZO6OZFxGYyn4x035pwGwjKGFuQRKYh0AtxwHiWeRIsAJ_B2Z-VGOpcSXH-x_YUfN8Q9FuyGUzcsVLuGizbooRSMSSoD_y_8veWOnXWbMsh0KKTON_-yTmAcLn2tOzFmsYgHQXatW0f2XjrdmmWl4VfiekFKFDvGenxum9nEJrzIJOMm6qHnIiyCNA3xbMqmr7oqeIUa-fQ",
+                        "e": "AQAB"
+                    }
+                ]
+            }
+            """
+
+        let rsaPrivateKeyPEM = """
+            -----BEGIN PRIVATE KEY-----
+            MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDL8W1D9w5zHpmD
+            JqpTngIRJ+Sm21e42cRnTudhdejzKUiJQWkHSvQV5yC/+0iEXUsUJYEdSyrKhJFD
+            PT+IFGdjIiwb7IX+rUreWXlD/YYBL3/byMG4kYoO4oiPp2A+WvfeyLpuN549OXhk
+            7o5kXEZjKfjHTfmnAbCMoYW5BEpiHQC3HAeJZ5EiwAn8HZn5UY6lxJcf7H9hR83x
+            D0W7IZTNyxUu4aLNuihFIxJKgP/L/y95Y6ddZsyyHQopM43/7JOYBwufa07MWaxi
+            AdBdq1bR/ZeOt2aZaXhV+J6QUoUO8Z6fG6b2cQmvMgk4ybqoeciLII0DfFsyqavu
+            ip4hRr59AgMBAAECggEAUIw994XwMw922hG/W98gOd5jtHMVJnD73UGQqTGEm+VG
+            PM+Ux8iWtr/ec3Svo3elW4OkhwlVET9ikAf0u64zVzf769ty4K9YzpDQEEZlUrqL
+            6SZVPKxetppKDVKx9G7BT0BAQZ+947h7EIIXwxOeyTOeijkFzSwhqqlwwy4qoqzV
+            FTQS20QHE62hxzwuS5HBqw8ds183qAg9NbzR0Cp4za9qTiBB6C8KEcLqeatO+q+d
+            VCDsJcAMZOvW14N6BozKgbQ/WXZQ/3kNUPBndZLzzqaILFNmB1Zf2DVVJ9gU7+EK
+            xOac60StIfG81NllCTBrmRVq8yitNqwmutHMlxrIkQKBgQDvp39MkEHtNunFGkI5
+            R8IB5BZjtx5OdRBKkmPasmNU8U0XoQAJUKY/9piIpCtRi87tMXv8WWmlbULi66pu
+            4BnMIisw78xlIWRZTSizFrkFcEoVgEnbZBtSrOg/J5PAcjLEGCQoAdmMXAekR2/m
+            htv7FPijHPNUjyIFLaxwjl9izwKBgQDZ2mQeKNRHjIb5ZBzB0ZCvUy2y4+kaLrhZ
+            +CWMN1flL4dd1KuZKvCEfHY9kWOjqw6XneN4yT0aPmbBft4fihiiNW0Sm8i+fSpy
+            g0klw2HJl49wnwctBpRgTdMKGo9n14OGeu0xKOAy7I4j1tKrUXiRWnP9R583Ti7c
+            w7YHgdHM8wKBgEV147SaPzF08A6bzMPzY2zO4hpmsdcFoQIsKdryR04QXkrR9EO+
+            52C0pYM9Kf0Jq6Ed7ZS3iaJT58YDjjNyqqd648/cQP6yzfYAIiK+HERSRnay5zU6
+            b5zn1qyvWOi3cLVbVedumdJPvjtEJU/ImKvOaT5FntVMYwzjLw60hTsLAoGAZJnt
+            UeAY51GFovUQMpDL96q5l7qXknewuhtVe4KzHCrun+3tsDWcDBJNp/DTymjbvDg1
+            KzoC9XOLkB8+A+KJrZ5uWAGImi7Cw07NIJsxNR7AJonJjolTS4Wkxy2su49SNW/e
+            yKzPm7SRjwtNDb/5pWXX2kaQx8Fa8qeOD7lrYPECgYAwQ6o0vYmr+L1tOZZgMVv9
+            Jusa8beVUH5hyduJjmxbYOtFTkggAozdx7rs4BgyRsmDlV48cEmcVf/7IH4gMJLb
+            O+bbERwCYUChe+piANhnwfwDHzbRd8mmQus54P06X7bWu6Rmi7gbQGVN/Z6VhbIm
+            D2cOo0w4bk/3yb01xz1MEw==
+            -----END PRIVATE KEY-----
+            """
+
         try await withApp { app in
-            app.jwt.apple.applicationIdentifier = "dev.timc.siwa-demo.TILiOS"
-
-            app.get("test") { req async throws in
-                try await req.jwt.apple.verify().email ?? "none"
+            app.get("mock-apple-jwks") { _ in
+                Response(
+                    status: .ok,
+                    headers: ["Content-Type": "application/json"],
+                    body: .init(string: mockJWKS)
+                )
             }
 
-            app.get("test2") { req async throws in
-                try await req.jwt.apple.verify(applicationIdentifier: "dev.timc.siwa-demo.TILiOS").email ?? "none"
+            app.get("apple-verify") { req async throws -> String in
+                let token = try await req.jwt.apple.verify()
+                return token.subject.value
             }
 
-            var headers = HTTPHeaders()
-            headers.bearerAuthorization = .init(
-                token: """
-                    eyJraWQiOiJVYUlJRlkyZlc0IiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiZGV2LnRpbWMuc2l3YS1kZW1vLlRJTGlPUyIsImV4cCI6MTc1NTYwMTY3MywiaWF0IjoxNzU1NTE1MjczLCJzdWIiOiIwMDE1NDIuYjA0MTAwYzUxYWNiNDhkM2E1NzA2ODRmMTdkNjM5NGQuMTYwMyIsImNfaGFzaCI6IjZtdnF4WmYzRHJIb3JPNnpleExQTVEiLCJlbWFpbCI6Ijh5c2JjaHZjMm1AcHJpdmF0ZXJlbGF5LmFwcGxlaWQuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImlzX3ByaXZhdGVfZW1haWwiOnRydWUsImF1dGhfdGltZSI6MTc1NTUxNTI3Mywibm9uY2Vfc3VwcG9ydGVkIjp0cnVlfQ.lvFfeDuAUKZV7ut9uaww1UICh5eDlU0bf-S5xzAzaS04xODvY_FtI7hKzJGm0YPx4hqR85Dalz-6XiCieJw0oxgVc0ZvpkmQ4R9DGZYS2v-fOSupr0BUqhTEqNNlVGCJhaGSOUq7lNWPKX2Fox9zL7x5IvhJ-J3Xj69xdMegezd7ahzOfBjirewqKm0osQYxzhGMvBfp3HxPhExfl7v3281n8p8FhMtYnxaFA1tGX3ncqpaoqYzT7kb-8DqbUDt83tuOC8qzSjeR0oI-gBWWihPQjj2g8rlAVPeDbQvXuUiVTtDowYFeAleE-OTV9KYZMw-gH69tB_ASD_yUwH_z7A
-                    """)
-
-            try await app.test(.GET, "test", headers: headers) { res async in
-                #expect(res.status == .unauthorized)
-                #expect(res.body.string.contains("expired"))
+            app.get("apple-verify-custom") { req async throws -> String in
+                let token = try await req.jwt.apple.verify(applicationIdentifier: "com.custom.app")
+                return token.subject.value
             }
 
-            try await app.test(.GET, "test2", headers: headers) { res async in
-                #expect(res.status == .unauthorized)
-                #expect(res.body.string.contains("expired"))
-            }
+            let privateKey = try Insecure.RSA.PrivateKey(pem: rsaPrivateKeyPEM)
+            let signingKeys = await JWTKeyCollection().add(
+                rsa: privateKey,
+                digestAlgorithm: .sha256,
+                kid: "test-apple-key"
+            )
+
+            // Valid token with correct application identifier
+            let validPayload = AppleIdentityToken(
+                issuer: "https://appleid.apple.com",
+                audience: "com.example.app",
+                expires: .init(value: Date().addingTimeInterval(3600)),
+                issuedAt: .init(value: Date()),
+                subject: "001234.abcdef1234567890.1234",
+                email: "test@privaterelay.appleid.com",
+                emailVerified: true
+            )
+            let validToken = try await signingKeys.sign(validPayload, kid: "test-apple-key")
+
+            try await app.server.start(address: .hostname("localhost", port: 0))
+            let port = try #require(app.http.server.shared.localAddress?.port, "Failed to get port")
+
+            app.jwt.apple.jwksEndpoint = "http://localhost:\(port)/mock-apple-jwks"
+            app.jwt.apple.applicationIdentifier = "com.example.app"
+
+            let verifyResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(validToken)"])
+            #expect(verifyResponse.status == .ok)
+            #expect(verifyResponse.body?.string == "001234.abcdef1234567890.1234")
+
+            // Token with wrong application identifier should fail
+            let wrongAudiencePayload = AppleIdentityToken(
+                issuer: "https://appleid.apple.com",
+                audience: "com.wrong.app",
+                expires: .init(value: Date().addingTimeInterval(3600)),
+                issuedAt: .init(value: Date()),
+                subject: "001234.abcdef1234567890.1234"
+            )
+            let wrongAudienceToken = try await signingKeys.sign(wrongAudiencePayload, kid: "test-apple-key")
+
+            let wrongAudienceResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongAudienceToken)"])
+            #expect(wrongAudienceResponse.status == .unauthorized)
+
+            // Expired token should fail
+            let expiredPayload = AppleIdentityToken(
+                issuer: "https://appleid.apple.com",
+                audience: "com.example.app",
+                expires: .init(value: Date().addingTimeInterval(-3600)),
+                issuedAt: .init(value: Date().addingTimeInterval(-7200)),
+                subject: "001234.abcdef1234567890.1234"
+            )
+            let expiredToken = try await signingKeys.sign(expiredPayload, kid: "test-apple-key")
+
+            let expiredTokenResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(expiredToken)"])
+            #expect(expiredTokenResponse.status == .unauthorized)
+
+            // Token with wrong issuer should fail
+            let wrongIssuerPayload = AppleIdentityToken(
+                issuer: "https://notapple.com",
+                audience: "com.example.app",
+                expires: .init(value: Date().addingTimeInterval(3600)),
+                issuedAt: .init(value: Date()),
+                subject: "001234.abcdef1234567890.1234"
+            )
+            let wrongIssuerToken = try await signingKeys.sign(wrongIssuerPayload, kid: "test-apple-key")
+
+            let wrongIssuerResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongIssuerToken)"])
+            #expect(wrongIssuerResponse.status == .unauthorized)
+
+            // Missing authorization header should fail
+            let missingAuthHeaderResponse = try await app.client.get("http://localhost:\(port)/apple-verify")
+            #expect(missingAuthHeaderResponse.status == .unauthorized)
+
+            // Verify application identifier can be overridden per-request
+            let customAudiencePayload = AppleIdentityToken(
+                issuer: "https://appleid.apple.com",
+                audience: "com.custom.app",
+                expires: .init(value: Date().addingTimeInterval(3600)),
+                issuedAt: .init(value: Date()),
+                subject: "custom-user-id"
+            )
+            let customToken = try await signingKeys.sign(customAudiencePayload, kid: "test-apple-key")
+
+            let customKidResponse = try await app.client.get("http://localhost:\(port)/apple-verify-custom", headers: ["Authorization": "Bearer \(customToken)"])
+            #expect(customKidResponse.status == .ok)
+            #expect(customKidResponse.body?.string == "custom-user-id")
+
+            await app.server.shutdown()
         }
     }
 

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -338,7 +338,8 @@ struct JWTTests {
             app.jwt.apple.jwksEndpoint = "http://localhost:\(port)/mock-apple-jwks"
             app.jwt.apple.applicationIdentifier = "com.example.app"
 
-            let verifyResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(validToken)"])
+            let verifyResponse = try await app.client.get(
+                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(validToken)"])
             #expect(verifyResponse.status == .ok)
             #expect(verifyResponse.body?.string == "001234.abcdef1234567890.1234")
 
@@ -352,7 +353,8 @@ struct JWTTests {
             )
             let wrongAudienceToken = try await signingKeys.sign(wrongAudiencePayload, kid: "test-apple-key")
 
-            let wrongAudienceResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongAudienceToken)"])
+            let wrongAudienceResponse = try await app.client.get(
+                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongAudienceToken)"])
             #expect(wrongAudienceResponse.status == .unauthorized)
 
             // Expired token should fail
@@ -365,7 +367,8 @@ struct JWTTests {
             )
             let expiredToken = try await signingKeys.sign(expiredPayload, kid: "test-apple-key")
 
-            let expiredTokenResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(expiredToken)"])
+            let expiredTokenResponse = try await app.client.get(
+                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(expiredToken)"])
             #expect(expiredTokenResponse.status == .unauthorized)
 
             // Token with wrong issuer should fail
@@ -378,7 +381,8 @@ struct JWTTests {
             )
             let wrongIssuerToken = try await signingKeys.sign(wrongIssuerPayload, kid: "test-apple-key")
 
-            let wrongIssuerResponse = try await app.client.get("http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongIssuerToken)"])
+            let wrongIssuerResponse = try await app.client.get(
+                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongIssuerToken)"])
             #expect(wrongIssuerResponse.status == .unauthorized)
 
             // Missing authorization header should fail
@@ -395,7 +399,8 @@ struct JWTTests {
             )
             let customToken = try await signingKeys.sign(customAudiencePayload, kid: "test-apple-key")
 
-            let customKidResponse = try await app.client.get("http://localhost:\(port)/apple-verify-custom", headers: ["Authorization": "Bearer \(customToken)"])
+            let customKidResponse = try await app.client.get(
+                "http://localhost:\(port)/apple-verify-custom", headers: ["Authorization": "Bearer \(customToken)"])
             #expect(customKidResponse.status == .ok)
             #expect(customKidResponse.body?.string == "custom-user-id")
 

--- a/Tests/JWTTests/JWTTests.swift
+++ b/Tests/JWTTests/JWTTests.swift
@@ -333,78 +333,83 @@ struct JWTTests {
             let validToken = try await signingKeys.sign(validPayload, kid: "test-apple-key")
 
             try await app.server.start(address: .hostname("localhost", port: 0))
-            let port = try #require(app.http.server.shared.localAddress?.port, "Failed to get port")
 
-            app.jwt.apple.jwksEndpoint = "http://localhost:\(port)/mock-apple-jwks"
-            app.jwt.apple.applicationIdentifier = "com.example.app"
+            do {
+                let port = try #require(app.http.server.shared.localAddress?.port, "Failed to get port")
 
-            let verifyResponse = try await app.client.get(
-                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(validToken)"])
-            #expect(verifyResponse.status == .ok)
-            #expect(verifyResponse.body?.string == "001234.abcdef1234567890.1234")
+                app.jwt.apple.jwksEndpoint = "http://localhost:\(port)/mock-apple-jwks"
+                app.jwt.apple.applicationIdentifier = "com.example.app"
 
-            // Token with wrong application identifier should fail
-            let wrongAudiencePayload = AppleIdentityToken(
-                issuer: "https://appleid.apple.com",
-                audience: "com.wrong.app",
-                expires: .init(value: Date().addingTimeInterval(3600)),
-                issuedAt: .init(value: Date()),
-                subject: "001234.abcdef1234567890.1234"
-            )
-            let wrongAudienceToken = try await signingKeys.sign(wrongAudiencePayload, kid: "test-apple-key")
+                let verifyResponse = try await app.client.get(
+                    "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(validToken)"])
+                #expect(verifyResponse.status == .ok)
+                #expect(verifyResponse.body?.string == "001234.abcdef1234567890.1234")
 
-            let wrongAudienceResponse = try await app.client.get(
-                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongAudienceToken)"])
-            #expect(wrongAudienceResponse.status == .unauthorized)
+                // Token with wrong application identifier should fail
+                let wrongAudiencePayload = AppleIdentityToken(
+                    issuer: "https://appleid.apple.com",
+                    audience: "com.wrong.app",
+                    expires: .init(value: Date().addingTimeInterval(3600)),
+                    issuedAt: .init(value: Date()),
+                    subject: "001234.abcdef1234567890.1234"
+                )
+                let wrongAudienceToken = try await signingKeys.sign(wrongAudiencePayload, kid: "test-apple-key")
 
-            // Expired token should fail
-            let expiredPayload = AppleIdentityToken(
-                issuer: "https://appleid.apple.com",
-                audience: "com.example.app",
-                expires: .init(value: Date().addingTimeInterval(-3600)),
-                issuedAt: .init(value: Date().addingTimeInterval(-7200)),
-                subject: "001234.abcdef1234567890.1234"
-            )
-            let expiredToken = try await signingKeys.sign(expiredPayload, kid: "test-apple-key")
+                let wrongAudienceResponse = try await app.client.get(
+                    "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongAudienceToken)"])
+                #expect(wrongAudienceResponse.status == .unauthorized)
 
-            let expiredTokenResponse = try await app.client.get(
-                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(expiredToken)"])
-            #expect(expiredTokenResponse.status == .unauthorized)
+                // Expired token should fail
+                let expiredPayload = AppleIdentityToken(
+                    issuer: "https://appleid.apple.com",
+                    audience: "com.example.app",
+                    expires: .init(value: Date().addingTimeInterval(-3600)),
+                    issuedAt: .init(value: Date().addingTimeInterval(-7200)),
+                    subject: "001234.abcdef1234567890.1234"
+                )
+                let expiredToken = try await signingKeys.sign(expiredPayload, kid: "test-apple-key")
 
-            // Token with wrong issuer should fail
-            let wrongIssuerPayload = AppleIdentityToken(
-                issuer: "https://notapple.com",
-                audience: "com.example.app",
-                expires: .init(value: Date().addingTimeInterval(3600)),
-                issuedAt: .init(value: Date()),
-                subject: "001234.abcdef1234567890.1234"
-            )
-            let wrongIssuerToken = try await signingKeys.sign(wrongIssuerPayload, kid: "test-apple-key")
+                let expiredTokenResponse = try await app.client.get(
+                    "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(expiredToken)"])
+                #expect(expiredTokenResponse.status == .unauthorized)
 
-            let wrongIssuerResponse = try await app.client.get(
-                "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongIssuerToken)"])
-            #expect(wrongIssuerResponse.status == .unauthorized)
+                // Token with wrong issuer should fail
+                let wrongIssuerPayload = AppleIdentityToken(
+                    issuer: "https://notapple.com",
+                    audience: "com.example.app",
+                    expires: .init(value: Date().addingTimeInterval(3600)),
+                    issuedAt: .init(value: Date()),
+                    subject: "001234.abcdef1234567890.1234"
+                )
+                let wrongIssuerToken = try await signingKeys.sign(wrongIssuerPayload, kid: "test-apple-key")
 
-            // Missing authorization header should fail
-            let missingAuthHeaderResponse = try await app.client.get("http://localhost:\(port)/apple-verify")
-            #expect(missingAuthHeaderResponse.status == .unauthorized)
+                let wrongIssuerResponse = try await app.client.get(
+                    "http://localhost:\(port)/apple-verify", headers: ["Authorization": "Bearer \(wrongIssuerToken)"])
+                #expect(wrongIssuerResponse.status == .unauthorized)
 
-            // Verify application identifier can be overridden per-request
-            let customAudiencePayload = AppleIdentityToken(
-                issuer: "https://appleid.apple.com",
-                audience: "com.custom.app",
-                expires: .init(value: Date().addingTimeInterval(3600)),
-                issuedAt: .init(value: Date()),
-                subject: "custom-user-id"
-            )
-            let customToken = try await signingKeys.sign(customAudiencePayload, kid: "test-apple-key")
+                // Missing authorization header should fail
+                let missingAuthHeaderResponse = try await app.client.get("http://localhost:\(port)/apple-verify")
+                #expect(missingAuthHeaderResponse.status == .unauthorized)
 
-            let customKidResponse = try await app.client.get(
-                "http://localhost:\(port)/apple-verify-custom", headers: ["Authorization": "Bearer \(customToken)"])
-            #expect(customKidResponse.status == .ok)
-            #expect(customKidResponse.body?.string == "custom-user-id")
+                // Verify application identifier can be overridden per-request
+                let customAudiencePayload = AppleIdentityToken(
+                    issuer: "https://appleid.apple.com",
+                    audience: "com.custom.app",
+                    expires: .init(value: Date().addingTimeInterval(3600)),
+                    issuedAt: .init(value: Date()),
+                    subject: "custom-user-id"
+                )
+                let customToken = try await signingKeys.sign(customAudiencePayload, kid: "test-apple-key")
 
-            await app.server.shutdown()
+                let customKidResponse = try await app.client.get(
+                    "http://localhost:\(port)/apple-verify-custom", headers: ["Authorization": "Bearer \(customToken)"])
+                #expect(customKidResponse.status == .ok)
+                #expect(customKidResponse.body?.string == "custom-user-id")
+
+                await app.server.shutdown()
+            } catch {
+                await app.server.shutdown()
+            }
         }
     }
 


### PR DESCRIPTION
The SIWA test has always been flaky because the key is cycled at regular intervals in Apple's JWKS keys. Previously we've had to do a complicated dance every couple of months to work around this and update the test (and wait a day for the token to expire as well otherwise it's updating the test every day).

This replaces the test entirely and takes advantage of the custom SIWA JWKS endpoints, replacing it with our own to emulate the real SIWA flow to provide hopefully a more stable test
